### PR TITLE
feat: phase 4 — hooks, context injection, session state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,89 @@
+# CLAUDE.md — openclaw-omg
+
+## Project Overview
+
+OpenClaw plugin — TypeScript ESM package.
+
+Key stacks: TypeScript 5.x, Node 20+, Vitest, Zod, pnpm.
+
+## Build & Run
+
+```bash
+pnpm install
+pnpm test          # full suite
+pnpm typecheck     # tsc --noEmit
+```
+
+---
+
+## PR Review Rules (MANDATORY)
+
+### Confidence threshold
+
+Only report issues with **confidence ≥ 80** (0–100 scale):
+- **91–100** → BLOCKER candidate
+- **80–90** → DEBT or NITPICK candidate
+- **< 80** → silently drop, do not report
+
+### Severity tiers — hard definitions
+
+| Tier | Definition | Action |
+|------|-----------|--------|
+| 🔴 BLOCKER | Data loss · security vuln · hard crash · broken test · wrong business logic · deadlock · unhandled production error | **Must fix before merge** |
+| 🟡 DEBT | Perf issue · missing edge case (non-critical) · refactor opportunity · unclear naming · missing test for happy path | **`gh issue create`, do not block merge** |
+| 🔵 NITPICK | Style · doc · minor inconsistency · naming preference | **Mention once, never escalate** |
+
+### Review process — 2 rounds HARD LIMIT
+
+1. **Round 1** — full diff pass. Categorize ALL ≥80-confidence findings as BLOCKER / DEBT / NITPICK.
+   Output in structured format below. Do not fix anything yet.
+2. **Fix phase** — author fixes BLOCKERs only. DEBT items → `gh issue create` immediately.
+3. **Round 2** — targeted re-run on **fixed files only** (not full diff). Flag NEW BLOCKERs
+   introduced by the fix. Do not re-raise old findings.
+   - Zero new BLOCKERs → **LGTM. Merge.**
+   - New BLOCKERs found → output them, **STOP. Human decides whether to merge.**
+4. **Session ends.** No further review rounds regardless of outcome.
+
+> ⚠️ The `review-pr` command's "Re-run after fixes" suggestion is **overridden** by these rules.
+> Only fixed files are re-checked in Round 2. This is still counted as Round 2.
+
+### Forbidden behaviors
+
+- ❌ NEVER upgrade a DEBT to BLOCKER between rounds
+- ❌ NEVER add unrelated findings in Round 2
+- ❌ NEVER run a full diff review in Round 2 (only fixed files)
+- ❌ NEVER block merge on "could be better", "should consider", "might cause issues"
+- ❌ NEVER repeat NITPICKS that were already noted
+- ❌ NEVER run Round 3, even if Round 2 reveals new BLOCKERs
+- ❌ NEVER auto-merge when Round 2 reveals new BLOCKERs — stop and wait for human
+- ❌ NEVER report issues with confidence < 80
+
+### Structured output format
+
+```
+## PR REVIEW — Round N: [branch or PR title]
+
+### 🔴 BLOCKERS (fix before merge)
+- [ ] `file.ts:42` — Description [confidence: 95]. Impact: [specific production harm]
+
+### 🟡 DEBT (gh issue create, merge anyway)
+- [ ] `file.ts:17` — Description [confidence: 82] → gh issue create
+
+### 🔵 NITPICKS (optional)
+- `file.ts:8` — Suggestion [confidence: 80]
+
+---
+BLOCKERS: N | DEBT: N | NITPICKS: N
+→ [MERGE READY / HUMAN DECISION REQUIRED: N new blockers from fix / N blockers remaining]
+```
+
+### Review prompt template (use this when invoking review)
+
+```
+Review this PR diff. Output ONLY in the structured format from CLAUDE.md.
+Severity rules are strict: BLOCKER = production harm only. Confidence threshold: ≥80.
+Scope: diff only — do not flag pre-existing issues outside the diff.
+This is Round [1/2].
+[Round 2: review ONLY files touched by the fix. Flag new BLOCKERs introduced by the fix.
+If new BLOCKERs found → STOP, human decides. No Round 3.]
+```

--- a/src/config.ts
+++ b/src/config.ts
@@ -120,14 +120,14 @@ const reflectorSchema = z
 
 /**
  * Controls when the Observer agent runs during a conversation.
- * The Observer is triggered when `pendingMessageTokens` exceeds
- * `messageTokenThreshold`, or manually via `triggerMode: 'manual'`.
+ * The Observer is triggered automatically based on `triggerMode`.
  */
 const observationSchema = z
   .object({
     /**
      * Accumulated token count of unprocessed messages that triggers an observation run.
      * Lower values = more frequent observation (higher LLM cost).
+     * Only used when `triggerMode` is `"threshold"`.
      */
     messageTokenThreshold: z
       .number()
@@ -137,9 +137,10 @@ const observationSchema = z
     /**
      * How observation runs are triggered:
      * - "threshold" — automatically when messageTokenThreshold is reached (default)
+     * - "every-turn" — after every agent turn regardless of token count (dev/test mode)
      * - "manual" — only when explicitly invoked via the observational-memory-graph skill
      */
-    triggerMode: z.enum(['threshold', 'manual']).default('threshold'),
+    triggerMode: z.enum(['threshold', 'every-turn', 'manual']).default('threshold'),
   })
   .strip()
 

--- a/src/context/renderer.ts
+++ b/src/context/renderer.ts
@@ -1,0 +1,56 @@
+import type { GraphContextSlice, GraphNode } from '../types.js'
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Renders a `GraphContextSlice` into a formatted string suitable for injection
+ * into the user turn of an agent prompt.
+ *
+ * Output structure:
+ * ```
+ * <omg-context>
+ * ## Memory Index
+ * {index content}
+ *
+ * ## Current State        ← omitted when nowNode is null
+ * {now node body}
+ *
+ * ## Relevant Knowledge   ← omitted when both mocs and nodes are empty
+ * ### {node description}
+ * {node body}
+ * ...
+ * </omg-context>
+ * ```
+ */
+export function renderContextBlock(slice: GraphContextSlice): string {
+  const sections: string[] = []
+
+  // Memory Index — always present
+  sections.push(`## Memory Index\n${slice.index}`)
+
+  // Current State — only when nowNode is present
+  if (slice.nowNode !== null) {
+    sections.push(`## Current State\n${slice.nowNode.body}`)
+  }
+
+  // Relevant Knowledge — only when there is something to show
+  const knowledgeItems = [...slice.mocs, ...slice.nodes]
+  if (knowledgeItems.length > 0) {
+    const rendered = knowledgeItems.map(renderNode).join('\n\n')
+    sections.push(`## Relevant Knowledge\n${rendered}`)
+  }
+
+  return `<omg-context>\n${sections.join('\n\n')}\n</omg-context>`
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderNode(node: GraphNode): string {
+  const { id, description, type, priority } = node.frontmatter
+  const meta = `<!-- ${id} | ${type} | ${priority} -->`
+  return `### ${description}\n${meta}\n${node.body}`
+}

--- a/src/context/selector.ts
+++ b/src/context/selector.ts
@@ -1,0 +1,199 @@
+import type { OmgConfig } from '../config.js'
+import type { GraphNode, GraphContextSlice, Message } from '../types.js'
+import { estimateTokens } from '../utils/tokens.js'
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface SelectionParams {
+  /** Full content of index.md (always injected). */
+  readonly indexContent: string
+  /** Full content of now.md, or null if it doesn't exist. */
+  readonly nowContent: string | null
+  /** All nodes currently in the graph (moc + regular). */
+  readonly allNodes: readonly GraphNode[]
+  /** Recent conversation messages used for keyword scoring. */
+  readonly recentMessages: readonly Message[]
+  readonly config: OmgConfig
+}
+
+/**
+ * Selects a ranked, budget-constrained slice of graph context for injection.
+ *
+ * Selection pipeline:
+ *   1. Always include index + now node (budget permitting)
+ *   2. Split allNodes into mocs and regular nodes
+ *   3. Score and rank each group
+ *   4. Enforce maxMocs / maxNodes counts
+ *   5. Force-include pinned nodes
+ *   6. Enforce token budget (drop lowest-scored nodes first)
+ */
+export function selectContext(params: SelectionParams): GraphContextSlice {
+  const { indexContent, nowContent, allNodes, recentMessages, config } = params
+  const { injection } = config
+
+  const keywords = extractKeywords(recentMessages)
+
+  // Partition nodes
+  const mocNodes = allNodes.filter((n) => n.frontmatter.type === 'moc')
+  const regularNodes = allNodes.filter(
+    (n) => n.frontmatter.type !== 'moc' && n.frontmatter.type !== 'index' && n.frontmatter.type !== 'now'
+  )
+
+  // Score and rank
+  const scoredMocs = scoreNodes(mocNodes, keywords).slice(0, injection.maxMocs)
+  const scoredRegular = scoreNodes(regularNodes, keywords)
+
+  // Collect pinned nodes (always included, de-duped)
+  const pinnedIds = new Set(injection.pinnedNodes)
+  const pinnedNodes = regularNodes.filter((n) => pinnedIds.has(n.frontmatter.id))
+  const pinnedIdSet = new Set(pinnedNodes.map((n) => n.frontmatter.id))
+
+  // Non-pinned regular nodes up to maxNodes
+  const nonPinned = scoredRegular
+    .filter((n) => !pinnedIdSet.has(n.frontmatter.id))
+    .slice(0, Math.max(0, injection.maxNodes - pinnedNodes.length))
+
+  // Enforce token budget
+  // Deduct pinned node costs upfront — they are always included regardless of budget.
+  const pinnedCost = pinnedNodes.reduce((sum, n) => sum + estimateTokens(nodeText(n)), 0)
+  let budget = injection.maxContextTokens
+  budget -= estimateTokens(indexContent)
+  if (nowContent !== null) budget -= estimateTokens(nowContent)
+  budget -= pinnedCost
+
+  const selectedMocs = fitInBudget(scoredMocs, budget / 2)
+  budget -= selectedMocs.reduce((sum, n) => sum + estimateTokens(nodeText(n)), 0)
+
+  const selectedNonPinned = fitInBudget(nonPinned, budget)
+  const selectedNodes = [...pinnedNodes, ...selectedNonPinned]
+
+  // Compute estimated tokens
+  const estTokens =
+    estimateTokens(indexContent) +
+    (nowContent !== null ? estimateTokens(nowContent) : 0) +
+    selectedMocs.reduce((sum, n) => sum + estimateTokens(nodeText(n)), 0) +
+    selectedNodes.reduce((sum, n) => sum + estimateTokens(nodeText(n)), 0)
+
+  const nowNode = nowContent !== null
+    ? buildNowNode(nowContent)
+    : null
+
+  return {
+    index: indexContent,
+    nowNode,
+    mocs: selectedMocs,
+    nodes: selectedNodes,
+    estimatedTokens: estTokens,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scoring
+// ---------------------------------------------------------------------------
+
+const PRIORITY_WEIGHT: Record<string, number> = {
+  high: 1.5,
+  medium: 1.0,
+  low: 0.7,
+}
+
+function scoreNodes(nodes: readonly GraphNode[], keywords: ReadonlySet<string>): GraphNode[] {
+  return [...nodes]
+    .map((node) => ({ node, score: computeScore(node, keywords) }))
+    .sort((a, b) => b.score - a.score)
+    .map(({ node }) => node)
+}
+
+function computeScore(node: GraphNode, keywords: ReadonlySet<string>): number {
+  const priorityWeight = PRIORITY_WEIGHT[node.frontmatter.priority] ?? 1.0
+  const recencyFactor = computeRecencyFactor(node.frontmatter.updated)
+  const keywordMatch = computeKeywordMatch(node, keywords)
+  return keywordMatch * priorityWeight * recencyFactor
+}
+
+function computeRecencyFactor(updatedIso: string): number {
+  const ts = new Date(updatedIso).getTime()
+  if (isNaN(ts)) {
+    console.error(`[omg] selectContext: invalid 'updated' date on node: ${JSON.stringify(updatedIso)} — defaulting recency factor to 0.5`)
+    return 0.5
+  }
+  const ageDays = (Date.now() - ts) / 86_400_000
+  return Math.max(0.5, 1.0 - ageDays * 0.02)
+}
+
+function computeKeywordMatch(node: GraphNode, keywords: ReadonlySet<string>): number {
+  if (keywords.size === 0) return 1.0
+  const text = (node.body + ' ' + (node.frontmatter.tags ?? []).join(' ')).toLowerCase()
+  let matches = 0
+  for (const kw of keywords) {
+    if (text.includes(kw)) matches++
+  }
+  // Base score 1.0 + bonus for keyword hits
+  return 1.0 + matches * 0.5
+}
+
+function extractKeywords(messages: readonly Message[]): ReadonlySet<string> {
+  const stopWords = new Set([
+    'the', 'a', 'an', 'is', 'are', 'was', 'were', 'be', 'been', 'being',
+    'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would', 'could',
+    'should', 'may', 'might', 'shall', 'can', 'to', 'of', 'in', 'for',
+    'on', 'with', 'at', 'by', 'from', 'as', 'into', 'through', 'and',
+    'or', 'but', 'if', 'then', 'that', 'this', 'it', 'its', 'i', 'you',
+    'me', 'my', 'your', 'we', 'our', 'they', 'them', 'their', 'not',
+    'help', 'about', 'what', 'how', 'when', 'where', 'who', 'which',
+  ])
+  const words = new Set<string>()
+  for (const msg of messages) {
+    for (const word of msg.content.toLowerCase().split(/\W+/)) {
+      if (word.length > 3 && !stopWords.has(word)) {
+        words.add(word)
+      }
+    }
+  }
+  return words
+}
+
+// ---------------------------------------------------------------------------
+// Budget enforcement
+// ---------------------------------------------------------------------------
+
+function fitInBudget(nodes: readonly GraphNode[], budget: number): GraphNode[] {
+  const result: GraphNode[] = []
+  let remaining = budget
+  for (const node of nodes) {
+    const cost = estimateTokens(nodeText(node))
+    if (remaining <= 0) break
+    if (cost <= remaining) {
+      result.push(node)
+      remaining -= cost
+    }
+  }
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function nodeText(node: GraphNode): string {
+  return node.frontmatter.description + '\n' + node.body
+}
+
+function buildNowNode(content: string): GraphNode {
+  const now = new Date().toISOString()
+  return {
+    frontmatter: {
+      id: 'omg/now',
+      description: 'Current state snapshot',
+      type: 'now',
+      priority: 'high',
+      created: now,
+      updated: now,
+    },
+    body: content,
+    // Synthetic in-memory node — not backed by a file on disk.
+    filePath: '',
+  }
+}

--- a/src/hooks/agent-end.ts
+++ b/src/hooks/agent-end.ts
@@ -1,0 +1,241 @@
+import type { OmgConfig } from '../config.js'
+import type { LlmClient } from '../llm/client.js'
+import type { Message, OmgSessionState, ObserverOutput } from '../types.js'
+import { createOmgSessionState } from '../types.js'
+import { loadSessionState, saveSessionState, getDefaultSessionState } from '../state/session-state.js'
+import { accumulateTokens, shouldTriggerObservation, shouldTriggerReflection } from '../state/token-tracker.js'
+import { runObservation } from '../observer/observer.js'
+import { writeObservationNode, writeNowNode } from '../graph/node-writer.js'
+import { applyMocUpdate, regenerateMoc } from '../graph/moc-manager.js'
+import { listAllNodes } from '../graph/node-reader.js'
+import { resolveOmgRoot, resolveMocPath } from '../utils/paths.js'
+import { readFileOrNull } from '../utils/fs.js'
+import path from 'node:path'
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface AgentEndEvent {
+  readonly success: boolean
+}
+
+export interface AgentEndContext {
+  readonly workspaceDir: string
+  readonly sessionKey: string
+  readonly messages: readonly Message[]
+  readonly config: OmgConfig
+  readonly llmClient: LlmClient
+}
+
+/**
+ * OpenClaw `agent_end` hook — triggers observation (and optionally reflection)
+ * after each agent turn.
+ *
+ * Never throws — all errors are caught and logged. State is always persisted
+ * even on partial failure.
+ */
+export async function agentEnd(event: AgentEndEvent, ctx: AgentEndContext): Promise<void> {
+  const { workspaceDir, sessionKey, messages, config, llmClient } = ctx
+  const omgRoot = resolveOmgRoot(workspaceDir, config)
+  const writeContext = { omgRoot, sessionKey }
+
+  const initialState = await loadSessionStateOrDefault(workspaceDir, sessionKey)
+  const accumulatedState = accumulateTokens(messages, initialState)
+
+  if (!shouldTriggerObservation(accumulatedState, config)) {
+    await persistState(workspaceDir, sessionKey, accumulatedState)
+    return
+  }
+
+  const finalState = await tryRunObservation(
+    messages, accumulatedState, config, llmClient, omgRoot, writeContext, sessionKey
+  )
+
+  await persistState(workspaceDir, sessionKey, finalState)
+}
+
+// ---------------------------------------------------------------------------
+// Observation cycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs the full observation cycle, returning the updated session state on
+ * success or the pre-observation state on any failure.
+ *
+ * Each phase logs a specific error message before returning early, so the
+ * outer caller does not need to re-log.
+ *
+ * Never throws.
+ */
+async function tryRunObservation(
+  messages: readonly Message[],
+  state: OmgSessionState,
+  config: OmgConfig,
+  llmClient: LlmClient,
+  omgRoot: string,
+  writeContext: { readonly omgRoot: string; readonly sessionKey: string },
+  sessionKey: string
+): Promise<OmgSessionState> {
+  // Phase 1: gather inputs and run LLM observation
+  // Do NOT advance observationBoundaryMessageIndex or reset pendingMessageTokens
+  // on failure — keeping them intact ensures the next turn re-attempts.
+  let observerOutput!: ObserverOutput
+  try {
+    const unobservedMessages = Array.from(messages.slice(state.observationBoundaryMessageIndex))
+    const allNodes = await listAllNodes(omgRoot)
+    const existingNodeIndex = allNodes.map((n) => ({
+      id: n.frontmatter.id,
+      description: n.frontmatter.description,
+    }))
+    const nowContent = await readFileOrNull(path.join(omgRoot, 'now.md'))
+    observerOutput = await runObservation({
+      unobservedMessages,
+      existingNodeIndex,
+      nowNode: nowContent,
+      config,
+      llmClient,
+      sessionContext: { sessionKey },
+    })
+  } catch (err) {
+    console.error(`[omg] agent_end [${sessionKey}]: LLM observation phase failed — state preserved for retry:`, err)
+    return state
+  }
+
+  // Phase 2: write observation nodes — partial failure is tolerated.
+  // Promise.allSettled prevents already-written nodes from being orphaned when a
+  // later write fails; only a total write failure returns the pre-observation state.
+  const writeResults = await Promise.allSettled(
+    observerOutput.operations.map((op) => writeObservationNode(op, writeContext))
+  )
+  const writtenNodes = writeResults
+    .filter((r): r is PromiseFulfilledResult<Awaited<ReturnType<typeof writeObservationNode>>> =>
+      r.status === 'fulfilled'
+    )
+    .map((r) => r.value)
+  const failedWrites = writeResults.filter((r): r is PromiseRejectedResult => r.status === 'rejected')
+  if (failedWrites.length > 0) {
+    console.error(
+      `[omg] agent_end [${sessionKey}]: ${failedWrites.length}/${writeResults.length} node write(s) failed:`,
+      failedWrites.map((f) => f.reason)
+    )
+  }
+  const writtenIds = writtenNodes.map((n) => n.frontmatter.id)
+  if (writtenIds.length === 0 && observerOutput.operations.length > 0) {
+    console.error(`[omg] agent_end [${sessionKey}]: all node writes failed — state preserved for retry`)
+    return state
+  }
+
+  // Phase 3: update MOCs
+  try {
+    // Apply MOC updates — read the graph once after all writes, not once per domain
+    const updatedNodes = await listAllNodes(omgRoot)
+    for (const domain of observerOutput.mocUpdates) {
+      const domainNodes = updatedNodes.filter((n) => n.frontmatter.tags?.includes(domain))
+      if (domainNodes.length > 0) {
+        await regenerateMoc(domain, domainNodes, omgRoot)
+      } else {
+        // No nodes tagged with this domain exist yet — add only written nodes that belong here
+        const mocPath = resolveMocPath(omgRoot, domain)
+        const domainWrittenIds = writtenNodes
+          .filter((n) => n.frontmatter.tags?.includes(domain))
+          .map((n) => n.frontmatter.id)
+        for (const id of domainWrittenIds) {
+          await applyMocUpdate(mocPath, { action: 'add', nodeId: id })
+        }
+      }
+    }
+  } catch (err) {
+    console.error(`[omg] agent_end [${sessionKey}]: MOC update phase failed — state preserved for retry:`, err)
+    return state
+  }
+
+  // Phase 4: update now node
+  if (observerOutput.nowUpdate !== null) {
+    try {
+      await writeNowNode(observerOutput.nowUpdate, writtenIds, writeContext)
+    } catch (err) {
+      console.error(`[omg] agent_end [${sessionKey}]: now-node write failed — state preserved for retry:`, err)
+      return state
+    }
+  }
+
+  // All phases succeeded — build updated state through the factory.
+  // createOmgSessionState validates invariants and can throw OmgSessionStateError;
+  // catching here preserves the "never throws" contract of tryRunObservation.
+  const tokensUsed = writtenIds.length > 0 ? state.pendingMessageTokens : 0
+  let updatedState: OmgSessionState
+  try {
+    updatedState = createOmgSessionState(
+      {
+        lastObservedAtMs: Date.now(),
+        pendingMessageTokens: 0,
+        totalObservationTokens: state.totalObservationTokens + tokensUsed,
+        observationBoundaryMessageIndex: messages.length,
+        nodeCount: state.nodeCount + writtenIds.length,
+        lastObservationNodeIds: writtenIds,
+      },
+      state.totalObservationTokens
+    )
+  } catch (err) {
+    console.error(`[omg] agent_end [${sessionKey}]: state factory threw after successful observation — state preserved:`, err)
+    return state
+  }
+
+  // Check for reflection (Phase 5 placeholder)
+  if (shouldTriggerReflection(updatedState, config)) {
+    console.error(
+      `[omg] agent_end [${sessionKey}]: reflection threshold reached but not yet implemented (Phase 5). ` +
+      `totalObservationTokens=${updatedState.totalObservationTokens}. Graph compression is being skipped.`
+    )
+  }
+
+  return updatedState
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Loads session state, falling back to the default state if the file is
+ * missing or unreadable. Never throws.
+ *
+ * Note: ENOENT is handled inside `loadSessionState` itself; errors reaching
+ * this catch are system-level (permissions, disk failure) and may be permanent.
+ */
+async function loadSessionStateOrDefault(
+  workspaceDir: string,
+  sessionKey: string
+): Promise<OmgSessionState> {
+  try {
+    return await loadSessionState(workspaceDir, sessionKey)
+  } catch (err) {
+    console.error(
+      `[omg] agent_end [${sessionKey}]: failed to load session state — system error detected, ` +
+      `check permissions on ${workspaceDir}. Falling back to defaults.`,
+      err
+    )
+    return getDefaultSessionState()
+  }
+}
+
+/**
+ * Persists session state. Never throws — logs on failure but does not
+ * propagate, preserving the "never throws" contract of `agentEnd`.
+ */
+async function persistState(
+  workspaceDir: string,
+  sessionKey: string,
+  state: OmgSessionState
+): Promise<void> {
+  try {
+    await saveSessionState(workspaceDir, sessionKey, state)
+  } catch (err) {
+    console.error(
+      `[omg] agent_end [${sessionKey}]: CRITICAL — failed to persist session state. ` +
+      'The completed observation will be re-run on the next turn, which may create duplicate graph nodes.',
+      err
+    )
+  }
+}

--- a/src/hooks/before-agent-start.ts
+++ b/src/hooks/before-agent-start.ts
@@ -1,0 +1,77 @@
+import type { OmgConfig } from '../config.js'
+import { listAllNodes } from '../graph/node-reader.js'
+import { resolveOmgRoot } from '../utils/paths.js'
+import { selectContext } from '../context/selector.js'
+import { renderContextBlock } from '../context/renderer.js'
+import { readFileOrNull } from '../utils/fs.js'
+import path from 'node:path'
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface BeforeAgentStartEvent {
+  readonly prompt: string
+}
+
+export interface BeforeAgentStartContext {
+  readonly workspaceDir: string
+  readonly sessionKey: string
+  readonly config: OmgConfig
+}
+
+export interface BeforeAgentStartResult {
+  readonly prependContext: string
+}
+
+/**
+ * OpenClaw `before_agent_start` hook — injects relevant memory context into
+ * the user turn before the agent processes its prompt.
+ *
+ * Returns `{ prependContext }` to be prepended to the user message, or
+ * `undefined` when the graph is empty and there is nothing to inject.
+ *
+ * Never throws — returns undefined on any error.
+ */
+export async function beforeAgentStart(
+  event: BeforeAgentStartEvent,
+  ctx: BeforeAgentStartContext
+): Promise<BeforeAgentStartResult | undefined> {
+  try {
+    const { workspaceDir, config } = ctx
+    const omgRoot = resolveOmgRoot(workspaceDir, config)
+
+    const [indexContent, nowContent, allNodes] = await Promise.all([
+      readFileOrNull(path.join(omgRoot, 'index.md')),
+      readFileOrNull(path.join(omgRoot, 'now.md')),
+      listAllNodes(omgRoot).catch((err) => {
+        console.error('[omg] before_agent_start: failed to list graph nodes:', err)
+        return []
+      }),
+    ])
+
+    // Nothing to inject when graph doesn't exist yet
+    if (indexContent === null && allNodes.length === 0) {
+      return undefined
+    }
+
+    const recentMessages = event.prompt
+      ? [{ role: 'user' as const, content: event.prompt }]
+      : []
+
+    const slice = selectContext({
+      indexContent: indexContent ?? '',
+      nowContent,
+      allNodes,
+      recentMessages,
+      config,
+    })
+
+    const prependContext = renderContextBlock(slice)
+    return { prependContext }
+  } catch (err) {
+    console.error('[omg] before_agent_start failed — context injection skipped:', err)
+    return undefined
+  }
+}
+

--- a/src/hooks/tool-result-persist.ts
+++ b/src/hooks/tool-result-persist.ts
@@ -1,0 +1,72 @@
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface ToolResultPersistEvent {
+  readonly toolName: string
+  readonly result: unknown
+}
+
+export interface ToolResultPersistResult {
+  readonly referencedNodeIds: readonly string[]
+}
+
+/**
+ * OpenClaw `tool_result_persist` hook — tags `memory_search` results with the
+ * OMG node IDs they reference, for use in context scoring on the next turn.
+ *
+ * Synchronous — runs on the transcript write hot path.
+ * Never throws — returns undefined on any error or non-matching tool.
+ *
+ * Returns a result tag object when `memory_search` references OMG nodes,
+ * otherwise returns `undefined` to leave the result unchanged.
+ */
+export function toolResultPersist(
+  event: ToolResultPersistEvent
+): ToolResultPersistResult | undefined {
+  if (event.toolName !== 'memory_search') return undefined
+
+  try {
+    const text = extractResultText(event.result)
+    const nodeIds = extractOmgNodeIds(text)
+    return { referencedNodeIds: nodeIds }
+  } catch (err) {
+    console.error('[omg] tool_result_persist: failed to extract node IDs from memory_search result:', err)
+    return undefined
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** OMG node ID pattern: starts with omg/, followed by path segments. */
+const OMG_NODE_ID_RE = /omg\/[a-z0-9][a-z0-9_/-]*/g
+
+function extractOmgNodeIds(text: string): string[] {
+  const matches = text.match(OMG_NODE_ID_RE) ?? []
+  return [...new Set(matches)]
+}
+
+function extractResultText(result: unknown): string {
+  if (result === null || result === undefined) return ''
+  if (typeof result === 'string') return result
+  if (typeof result !== 'object') return String(result)
+
+  const obj = result as Record<string, unknown>
+
+  // Handle { content: Array<{ type, text }> } shape (OpenClaw standard)
+  if (Array.isArray(obj['content'])) {
+    return (obj['content'] as unknown[])
+      .map((block) => {
+        if (typeof block === 'object' && block !== null) {
+          const b = block as Record<string, unknown>
+          return typeof b['text'] === 'string' ? b['text'] : ''
+        }
+        return ''
+      })
+      .join(' ')
+  }
+
+  return JSON.stringify(result)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,3 +41,30 @@ export { runObservation } from './observer/observer.js'
 export { parseObserverOutput } from './observer/parser.js'
 export { buildObserverSystemPrompt, buildObserverUserPrompt } from './observer/prompts.js'
 export type { ObserverUserPromptParams } from './observer/prompts.js'
+
+export { selectContext } from './context/selector.js'
+export { renderContextBlock } from './context/renderer.js'
+export type { SelectionParams } from './context/selector.js'
+
+export { loadSessionState, saveSessionState, getDefaultSessionState } from './state/session-state.js'
+export { accumulateTokens, shouldTriggerObservation, shouldTriggerReflection } from './state/token-tracker.js'
+
+export { agentEnd } from './hooks/agent-end.js'
+export { beforeAgentStart } from './hooks/before-agent-start.js'
+export { toolResultPersist } from './hooks/tool-result-persist.js'
+export type {
+  AgentEndEvent,
+  AgentEndContext,
+} from './hooks/agent-end.js'
+export type {
+  BeforeAgentStartEvent,
+  BeforeAgentStartContext,
+  BeforeAgentStartResult,
+} from './hooks/before-agent-start.js'
+export type {
+  ToolResultPersistEvent,
+  ToolResultPersistResult,
+} from './hooks/tool-result-persist.js'
+
+export { register } from './plugin.js'
+export type { PluginApi, PluginHookContext } from './plugin.js'

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,0 +1,126 @@
+/**
+ * plugin.ts — OpenClaw plugin entry point for the OMG (Observational Memory Graph) plugin.
+ *
+ * Exports a `register(api)` function that wires the three lifecycle hooks:
+ *   - `before_agent_start` — injects relevant graph context before the agent runs
+ *   - `agent_end`          — triggers observation after each agent turn
+ *   - `tool_result_persist` — tags memory_search results with referenced node IDs
+ *
+ * OpenClaw plugins can export either a function `(api) => void` or an object
+ * with `{ id, name, configSchema, register(api) { ... } }`. This module
+ * exports the named `register` function for explicit wiring and a default
+ * export for OpenClaw's auto-discovery.
+ */
+
+import { parseConfig } from './config.js'
+import { createLlmClient } from './llm/client.js'
+import { agentEnd } from './hooks/agent-end.js'
+import { beforeAgentStart } from './hooks/before-agent-start.js'
+import { toolResultPersist } from './hooks/tool-result-persist.js'
+import type { Message } from './types.js'
+import type { GenerateFn } from './llm/client.js'
+
+// ---------------------------------------------------------------------------
+// Plugin API types (OpenClaw plugin interface)
+// ---------------------------------------------------------------------------
+
+/** Context provided per hook call for session-scoped hooks. */
+export interface PluginHookContext {
+  /** Stable identifier for the current conversation session. */
+  readonly sessionKey: string
+  /**
+   * Conversation messages accumulated so far in this session.
+   * Only present on `agent_end` hooks.
+   */
+  readonly messages?: readonly Message[]
+}
+
+/**
+ * Minimal OpenClaw plugin API surface used by this plugin.
+ *
+ * OpenClaw passes this object to `register(api)`. The actual API has
+ * additional methods not used by OMG; only the relevant subset is typed here.
+ */
+export interface PluginApi {
+  /**
+   * Raw plugin configuration as supplied by the operator (parsed from
+   * workspace/managed config). Corresponds to the OMG config schema.
+   * Must be passed through {@link parseConfig} before use — it is unvalidated at this point.
+   */
+  readonly config: Record<string, unknown>
+
+  /** Absolute path to the workspace root directory on the gateway host. */
+  readonly workspaceDir: string
+
+  /**
+   * OpenClaw's LLM generation function. Used to create the observer's
+   * LlmClient. Model selection and auth are handled by the host.
+   */
+  readonly generate: GenerateFn
+
+  /** Register a handler for the `before_agent_start` lifecycle hook. */
+  on(
+    hook: 'before_agent_start',
+    handler: (
+      event: { prompt: string },
+      ctx: PluginHookContext
+    ) => Promise<{ prependContext: string } | undefined>
+  ): void
+
+  /** Register a handler for the `agent_end` lifecycle hook. */
+  on(
+    hook: 'agent_end',
+    handler: (
+      event: { success: boolean },
+      ctx: Required<PluginHookContext>
+    ) => Promise<void>
+  ): void
+
+  /** Register a handler for the synchronous `tool_result_persist` lifecycle hook. */
+  on(
+    hook: 'tool_result_persist',
+    handler: (
+      event: { toolName: string; result: unknown }
+    ) => { referencedNodeIds: readonly string[] } | undefined
+  ): void
+}
+
+// ---------------------------------------------------------------------------
+// Plugin registration
+// ---------------------------------------------------------------------------
+
+/**
+ * Registers all OMG lifecycle hooks with the OpenClaw plugin API.
+ *
+ * Call this once during plugin initialisation. The function is idempotent
+ * when called on the same `api` instance.
+ *
+ * @param api  The OpenClaw plugin API object provided at plugin load time.
+ */
+export function register(api: PluginApi): void {
+  const config = parseConfig(api.config)
+  const { workspaceDir } = api
+
+  // Model label used only for error-message attribution; actual model
+  // selection is owned by the host via api.generate.
+  const observerModel = config.observer.model ?? '(inherited)'
+  const llmClient = createLlmClient(observerModel, api.generate)
+
+  api.on('before_agent_start', (event, ctx) =>
+    beforeAgentStart(event, { workspaceDir, sessionKey: ctx.sessionKey, config })
+  )
+
+  api.on('agent_end', (event, ctx) =>
+    agentEnd(event, {
+      workspaceDir,
+      sessionKey: ctx.sessionKey,
+      messages: ctx.messages,
+      config,
+      llmClient,
+    })
+  )
+
+  api.on('tool_result_persist', (event) => toolResultPersist(event))
+}
+
+export default register

--- a/src/state/session-state.ts
+++ b/src/state/session-state.ts
@@ -1,0 +1,97 @@
+import { mkdir, readFile } from 'node:fs/promises'
+import path from 'node:path'
+import type { OmgSessionState } from '../types.js'
+import { atomicWrite, isEnoent } from '../utils/fs.js'
+import { resolveStatePath } from '../utils/paths.js'
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/** Returns a fresh session state with all fields at their zero/empty defaults. */
+export function getDefaultSessionState(): OmgSessionState {
+  return {
+    lastObservedAtMs: 0,
+    pendingMessageTokens: 0,
+    totalObservationTokens: 0,
+    observationBoundaryMessageIndex: 0,
+    nodeCount: 0,
+    lastObservationNodeIds: [],
+  }
+}
+
+/**
+ * Loads session state from `.omg-state/{sessionKey}.json`.
+ * Returns the default state when the file does not exist or contains invalid JSON.
+ */
+export async function loadSessionState(
+  workspaceDir: string,
+  sessionKey: string
+): Promise<OmgSessionState> {
+  const statePath = resolveStatePath(workspaceDir, sessionKey)
+  let raw: string
+  try {
+    raw = await readFile(statePath, 'utf-8')
+  } catch (err) {
+    if (isEnoent(err)) return getDefaultSessionState()
+    throw err
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    return hydrateState(parsed)
+  } catch (err) {
+    console.error(
+      `[omg] loadSessionState: state file at ${statePath} contains invalid JSON — resetting to defaults. ` +
+      'This may cause duplicate observation of prior messages.',
+      err
+    )
+    return getDefaultSessionState()
+  }
+}
+
+/**
+ * Atomically persists session state to `.omg-state/{sessionKey}.json`.
+ * Creates the directory if it does not exist.
+ */
+export async function saveSessionState(
+  workspaceDir: string,
+  sessionKey: string,
+  state: OmgSessionState
+): Promise<void> {
+  const statePath = resolveStatePath(workspaceDir, sessionKey)
+  await mkdir(path.dirname(statePath), { recursive: true })
+  await atomicWrite(statePath, JSON.stringify(state, null, 2))
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Coerces a parsed JSON value into a valid OmgSessionState.
+ * Falls back gracefully for any missing or invalid fields.
+ */
+function hydrateState(parsed: unknown): OmgSessionState {
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return getDefaultSessionState()
+  }
+  const obj = parsed as Record<string, unknown>
+  return {
+    lastObservedAtMs: toNonNegativeNumber(obj['lastObservedAtMs']),
+    pendingMessageTokens: toNonNegativeNumber(obj['pendingMessageTokens']),
+    totalObservationTokens: toNonNegativeNumber(obj['totalObservationTokens']),
+    observationBoundaryMessageIndex: toNonNegativeNumber(obj['observationBoundaryMessageIndex']),
+    nodeCount: toNonNegativeNumber(obj['nodeCount']),
+    lastObservationNodeIds: toStringArray(obj['lastObservationNodeIds']),
+  }
+}
+
+function toNonNegativeNumber(v: unknown): number {
+  if (typeof v === 'number' && isFinite(v) && v >= 0) return v
+  return 0
+}
+
+function toStringArray(v: unknown): string[] {
+  if (Array.isArray(v)) return v.filter((x): x is string => typeof x === 'string')
+  return []
+}

--- a/src/state/token-tracker.ts
+++ b/src/state/token-tracker.ts
@@ -1,0 +1,58 @@
+import type { OmgConfig } from '../config.js'
+import type { Message, OmgSessionState } from '../types.js'
+import { estimateTokens } from '../utils/tokens.js'
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Recalculates the token count of messages not yet processed by the Observer.
+ * Only messages after `state.observationBoundaryMessageIndex` are counted.
+ *
+ * Pure function — returns a new state object, never mutates the original.
+ * Replaces (rather than adds to) `pendingMessageTokens`, so it is safe to
+ * call multiple times across turns without double-counting.
+ */
+export function accumulateTokens(
+  messages: readonly Message[],
+  state: OmgSessionState
+): OmgSessionState {
+  const unobserved = messages.slice(state.observationBoundaryMessageIndex)
+  const newTokens = unobserved.reduce((sum, msg) => sum + estimateTokens(msg.content), 0)
+  return {
+    ...state,
+    pendingMessageTokens: newTokens,
+  }
+}
+
+/**
+ * Returns true if an observation run should be triggered based on the current
+ * state and configuration.
+ *
+ * - `"every-turn"` — always returns true
+ * - `"threshold"` — returns true when `pendingMessageTokens >= messageTokenThreshold`
+ * - `"manual"` — always returns false (trigger via skill only)
+ *
+ * Pure function — no side effects.
+ */
+export function shouldTriggerObservation(state: OmgSessionState, config: OmgConfig): boolean {
+  switch (config.observation.triggerMode) {
+    case 'every-turn':
+      return true
+    case 'threshold':
+      return state.pendingMessageTokens >= config.observation.messageTokenThreshold
+    case 'manual':
+      return false
+  }
+}
+
+/**
+ * Returns true if a reflection pass should be triggered based on the cumulative
+ * observation token count.
+ *
+ * Pure function — no side effects.
+ */
+export function shouldTriggerReflection(state: OmgSessionState, config: OmgConfig): boolean {
+  return state.totalObservationTokens >= config.reflection.observationTokenThreshold
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -312,8 +312,10 @@ export interface OmgSessionState {
   readonly totalObservationTokens: number
   /** 0-based index of the last message included in the previous Observer run. */
   readonly observationBoundaryMessageIndex: number
-  /** Current total count of nodes in the graph. */
+  /** Cumulative count of nodes written by the Observer across all turns in this session. May diverge from the live graph size after deletions or state resets. */
   readonly nodeCount: number
+  /** IDs of nodes written during the most recent Observer run. Empty if no observation has run. */
+  readonly lastObservationNodeIds: readonly string[]
 }
 
 /**
@@ -342,6 +344,7 @@ export function createOmgSessionState(
     readonly totalObservationTokens: number
     readonly observationBoundaryMessageIndex: number
     readonly nodeCount: number
+    readonly lastObservationNodeIds: readonly string[]
   },
   previousTotalObservationTokens?: number
 ): OmgSessionState {

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -14,6 +14,19 @@ export function isEnoent(err: unknown): boolean {
 }
 
 /**
+ * Reads a file as UTF-8 text, returning null if the file does not exist.
+ * Rethrows any error that is not ENOENT.
+ */
+export async function readFileOrNull(filePath: string): Promise<string | null> {
+  try {
+    return await fs.readFile(filePath, 'utf-8')
+  } catch (err) {
+    if (isEnoent(err)) return null
+    throw err
+  }
+}
+
+/**
  * Writes content to a temporary file in the same directory as filePath,
  * then atomically renames it to filePath. Prevents partial writes from
  * being observed by readers.

--- a/tests/unit/agent-end.test.ts
+++ b/tests/unit/agent-end.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { vol } from 'memfs'
+import { parseConfig } from '../../src/config.js'
+import type { LlmClient } from '../../src/llm/client.js'
+import type { Message } from '../../src/types.js'
+
+vi.mock('node:fs', async () => {
+  const m = await vi.importActual<typeof import('memfs')>('memfs')
+  return { default: m.fs, ...m.fs }
+})
+vi.mock('node:fs/promises', async () => {
+  const m = await vi.importActual<typeof import('memfs')>('memfs')
+  return { default: m.fs.promises, ...m.fs.promises }
+})
+
+const { agentEnd } = await import('../../src/hooks/agent-end.js')
+
+const WORKSPACE = '/workspace'
+const SESSION_KEY = 'test-session'
+const OMG_ROOT = `${WORKSPACE}/memory/omg`
+
+function makeMockLlmClient(responseXml?: string): LlmClient {
+  return {
+    generate: vi.fn().mockResolvedValue({
+      content: responseXml ?? '<observations></observations>',
+      usage: { inputTokens: 100, outputTokens: 50 },
+    }),
+  }
+}
+
+function makeMessages(count: number): Message[] {
+  return Array.from({ length: count }, (_, i) => ({
+    role: i % 2 === 0 ? 'user' : 'assistant',
+    content: `Message ${i} content with some words to accumulate tokens.`,
+  }))
+}
+
+beforeEach(() => {
+  vol.reset()
+  // Scaffold minimal graph directories
+  vol.fromJSON({
+    [`${OMG_ROOT}/index.md`]: '---\ntype: index\nid: omg/index\npriority: high\ncreated: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\n---\n# Index\n',
+    [`${OMG_ROOT}/now.md`]: '---\ntype: now\nid: omg/now\npriority: high\ncreated: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\n---\n# Now\nInitial state.',
+  })
+})
+
+// ---------------------------------------------------------------------------
+// agentEnd — no-op paths
+// ---------------------------------------------------------------------------
+
+describe('agentEnd — below threshold', () => {
+  it('does not call LLM when below token threshold', async () => {
+    const config = parseConfig({ observation: { triggerMode: 'threshold', messageTokenThreshold: 30_000 } })
+    const llmClient = makeMockLlmClient()
+
+    await agentEnd(
+      { success: true },
+      { workspaceDir: WORKSPACE, sessionKey: SESSION_KEY, messages: makeMessages(2), config, llmClient }
+    )
+
+    expect(llmClient.generate).not.toHaveBeenCalled()
+  })
+
+  it('saves updated state even when observation does not trigger', async () => {
+    const config = parseConfig({ observation: { triggerMode: 'threshold', messageTokenThreshold: 30_000 } })
+    const llmClient = makeMockLlmClient()
+
+    await agentEnd(
+      { success: true },
+      { workspaceDir: WORKSPACE, sessionKey: SESSION_KEY, messages: makeMessages(2), config, llmClient }
+    )
+
+    const { fs } = await import('memfs')
+    const stateExists = fs.existsSync(`${WORKSPACE}/.omg-state/${SESSION_KEY}.json`)
+    expect(stateExists).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// agentEnd — every-turn mode
+// ---------------------------------------------------------------------------
+
+describe('agentEnd — every-turn mode', () => {
+  it('calls LLM on every turn regardless of token count', async () => {
+    const config = parseConfig({ observation: { triggerMode: 'every-turn' } })
+    const llmClient = makeMockLlmClient()
+
+    await agentEnd(
+      { success: true },
+      { workspaceDir: WORKSPACE, sessionKey: SESSION_KEY, messages: makeMessages(2), config, llmClient }
+    )
+
+    expect(llmClient.generate).toHaveBeenCalledTimes(1)
+  })
+
+  it('updates session state boundary after observation', async () => {
+    const config = parseConfig({ observation: { triggerMode: 'every-turn' } })
+    const llmClient = makeMockLlmClient()
+    const messages = makeMessages(4)
+
+    await agentEnd(
+      { success: true },
+      { workspaceDir: WORKSPACE, sessionKey: SESSION_KEY, messages, config, llmClient }
+    )
+
+    const { loadSessionState } = await import('../../src/state/session-state.js')
+    const state = await loadSessionState(WORKSPACE, SESSION_KEY)
+    expect(state.observationBoundaryMessageIndex).toBe(messages.length)
+  })
+
+  it('resets pendingMessageTokens to 0 after observation', async () => {
+    const config = parseConfig({ observation: { triggerMode: 'every-turn' } })
+    const llmClient = makeMockLlmClient()
+
+    await agentEnd(
+      { success: true },
+      { workspaceDir: WORKSPACE, sessionKey: SESSION_KEY, messages: makeMessages(3), config, llmClient }
+    )
+
+    const { loadSessionState } = await import('../../src/state/session-state.js')
+    const state = await loadSessionState(WORKSPACE, SESSION_KEY)
+    expect(state.pendingMessageTokens).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// agentEnd — observation with node writes
+// ---------------------------------------------------------------------------
+
+describe('agentEnd — observation with node output', () => {
+  it('writes observation nodes when LLM returns operations', async () => {
+    const xml = `<observations>
+<operations>
+<operation action="create" type="fact" priority="medium">
+  <id>omg/typescript-types</id>
+  <description>TypeScript is strongly typed</description>
+  <content>TypeScript adds static types to JavaScript.</content>
+</operation>
+</operations>
+</observations>`
+
+    const config = parseConfig({ observation: { triggerMode: 'every-turn' } })
+    const llmClient = makeMockLlmClient(xml)
+
+    await agentEnd(
+      { success: true },
+      { workspaceDir: WORKSPACE, sessionKey: SESSION_KEY, messages: makeMessages(2), config, llmClient }
+    )
+
+    const { fs } = await import('memfs')
+    const nodeDir = `${OMG_ROOT}/nodes/fact`
+    const files = fs.readdirSync(nodeDir) as string[]
+    expect(files.length).toBeGreaterThan(0)
+  })
+
+  it('updates lastObservationNodeIds in state after writing nodes', async () => {
+    const xml = `<observations>
+<operations>
+<operation action="create" type="fact" priority="high">
+  <id>omg/new-observation-fact</id>
+  <description>A new observation fact</description>
+  <content>This is an important fact.</content>
+</operation>
+</operations>
+</observations>`
+
+    const config = parseConfig({ observation: { triggerMode: 'every-turn' } })
+    const llmClient = makeMockLlmClient(xml)
+
+    await agentEnd(
+      { success: true },
+      { workspaceDir: WORKSPACE, sessionKey: SESSION_KEY, messages: makeMessages(2), config, llmClient }
+    )
+
+    const { loadSessionState } = await import('../../src/state/session-state.js')
+    const state = await loadSessionState(WORKSPACE, SESSION_KEY)
+    expect(state.lastObservationNodeIds.length).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// agentEnd — error resilience
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// agentEnd — manual mode
+// ---------------------------------------------------------------------------
+
+describe('agentEnd — manual mode', () => {
+  it('does not call LLM when triggerMode is manual', async () => {
+    const config = parseConfig({ observation: { triggerMode: 'manual' } })
+    const llmClient = makeMockLlmClient()
+
+    await agentEnd(
+      { success: true },
+      { workspaceDir: WORKSPACE, sessionKey: SESSION_KEY, messages: makeMessages(2), config, llmClient }
+    )
+
+    expect(llmClient.generate).not.toHaveBeenCalled()
+  })
+
+  it('saves state even in manual mode', async () => {
+    const config = parseConfig({ observation: { triggerMode: 'manual' } })
+    const llmClient = makeMockLlmClient()
+
+    await agentEnd(
+      { success: true },
+      { workspaceDir: WORKSPACE, sessionKey: SESSION_KEY, messages: makeMessages(2), config, llmClient }
+    )
+
+    const { fs } = await import('memfs')
+    expect(fs.existsSync(`${WORKSPACE}/.omg-state/${SESSION_KEY}.json`)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// agentEnd — error resilience
+// ---------------------------------------------------------------------------
+
+describe('agentEnd — error resilience', () => {
+  it('never throws even when LLM client throws', async () => {
+    const config = parseConfig({ observation: { triggerMode: 'every-turn' } })
+    const llmClient: LlmClient = {
+      generate: vi.fn().mockRejectedValue(new Error('LLM API error')),
+    }
+
+    await expect(
+      agentEnd(
+        { success: true },
+        { workspaceDir: WORKSPACE, sessionKey: SESSION_KEY, messages: makeMessages(2), config, llmClient }
+      )
+    ).resolves.toBeUndefined()
+  })
+
+  it('still saves state even when observation fails', async () => {
+    const config = parseConfig({ observation: { triggerMode: 'every-turn' } })
+    const llmClient: LlmClient = {
+      generate: vi.fn().mockRejectedValue(new Error('LLM unavailable')),
+    }
+
+    await agentEnd(
+      { success: true },
+      { workspaceDir: WORKSPACE, sessionKey: SESSION_KEY, messages: makeMessages(2), config, llmClient }
+    )
+
+    const { fs } = await import('memfs')
+    expect(fs.existsSync(`${WORKSPACE}/.omg-state/${SESSION_KEY}.json`)).toBe(true)
+  })
+
+  it('does not advance observationBoundaryMessageIndex when observation fails', async () => {
+    const config = parseConfig({ observation: { triggerMode: 'every-turn' } })
+    const llmClient: LlmClient = {
+      generate: vi.fn().mockRejectedValue(new Error('LLM unavailable')),
+    }
+    const messages = makeMessages(4)
+
+    await agentEnd(
+      { success: true },
+      { workspaceDir: WORKSPACE, sessionKey: SESSION_KEY, messages, config, llmClient }
+    )
+
+    const { loadSessionState } = await import('../../src/state/session-state.js')
+    const state = await loadSessionState(WORKSPACE, SESSION_KEY)
+    // Boundary must NOT advance — the next turn must retry the same messages
+    expect(state.observationBoundaryMessageIndex).toBe(0)
+    // Pending tokens must NOT reset — ensures retry accumulates correctly
+    expect(state.pendingMessageTokens).toBeGreaterThan(0)
+  })
+})

--- a/tests/unit/before-agent-start.test.ts
+++ b/tests/unit/before-agent-start.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { vol } from 'memfs'
+import { parseConfig } from '../../src/config.js'
+
+vi.mock('node:fs', async () => {
+  const m = await vi.importActual<typeof import('memfs')>('memfs')
+  return { default: m.fs, ...m.fs }
+})
+vi.mock('node:fs/promises', async () => {
+  const m = await vi.importActual<typeof import('memfs')>('memfs')
+  return { default: m.fs.promises, ...m.fs.promises }
+})
+
+const { beforeAgentStart } = await import('../../src/hooks/before-agent-start.js')
+
+const WORKSPACE = '/workspace'
+const SESSION_KEY = 'test-session'
+const OMG_ROOT = `${WORKSPACE}/memory/omg`
+
+const INDEX_MD = '---\ntype: index\nid: omg/index\npriority: high\ncreated: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\n---\n# Memory Index\n- [[omg/moc-projects]]\n'
+const NOW_MD = '---\ntype: now\nid: omg/now\npriority: high\ncreated: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\n---\n# Now\nWorking on something.\n'
+
+beforeEach(() => {
+  vol.reset()
+})
+
+// ---------------------------------------------------------------------------
+// beforeAgentStart — happy paths
+// ---------------------------------------------------------------------------
+
+describe('beforeAgentStart — graph present', () => {
+  it('returns an object with prependContext string', async () => {
+    vol.fromJSON({
+      [`${OMG_ROOT}/index.md`]: INDEX_MD,
+      [`${OMG_ROOT}/now.md`]: NOW_MD,
+    })
+
+    const config = parseConfig({})
+    const result = await beforeAgentStart(
+      { prompt: 'Help me with TypeScript.' },
+      { workspaceDir: WORKSPACE, sessionKey: SESSION_KEY, config }
+    )
+
+    expect(result).toBeDefined()
+    expect(typeof result?.prependContext).toBe('string')
+    expect(result?.prependContext.length).toBeGreaterThan(0)
+  })
+
+  it('prependContext contains <omg-context> wrapper', async () => {
+    vol.fromJSON({
+      [`${OMG_ROOT}/index.md`]: INDEX_MD,
+      [`${OMG_ROOT}/now.md`]: NOW_MD,
+    })
+
+    const config = parseConfig({})
+    const result = await beforeAgentStart(
+      { prompt: 'Hello.' },
+      { workspaceDir: WORKSPACE, sessionKey: SESSION_KEY, config }
+    )
+
+    expect(result?.prependContext).toContain('<omg-context>')
+    expect(result?.prependContext).toContain('</omg-context>')
+  })
+
+  it('prependContext includes index content', async () => {
+    vol.fromJSON({
+      [`${OMG_ROOT}/index.md`]: INDEX_MD,
+    })
+
+    const config = parseConfig({})
+    const result = await beforeAgentStart(
+      { prompt: 'Hello.' },
+      { workspaceDir: WORKSPACE, sessionKey: SESSION_KEY, config }
+    )
+
+    expect(result?.prependContext).toContain('Memory Index')
+  })
+
+  it('includes now node content when now.md exists', async () => {
+    vol.fromJSON({
+      [`${OMG_ROOT}/index.md`]: INDEX_MD,
+      [`${OMG_ROOT}/now.md`]: NOW_MD,
+    })
+
+    const config = parseConfig({})
+    const result = await beforeAgentStart(
+      { prompt: 'Hello.' },
+      { workspaceDir: WORKSPACE, sessionKey: SESSION_KEY, config }
+    )
+
+    expect(result?.prependContext).toContain('Working on something.')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// beforeAgentStart — empty graph
+// ---------------------------------------------------------------------------
+
+describe('beforeAgentStart — empty graph', () => {
+  it('returns undefined when graph directory does not exist', async () => {
+    const config = parseConfig({})
+    const result = await beforeAgentStart(
+      { prompt: 'Hello.' },
+      { workspaceDir: WORKSPACE, sessionKey: SESSION_KEY, config }
+    )
+
+    // No index.md and no nodes → nothing to inject
+    expect(result).toBeUndefined()
+  })
+
+  it('never throws when graph is completely empty', async () => {
+    const config = parseConfig({})
+    await expect(
+      beforeAgentStart(
+        { prompt: 'Hello.' },
+        { workspaceDir: WORKSPACE, sessionKey: SESSION_KEY, config }
+      )
+    ).resolves.not.toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// beforeAgentStart — knowledge nodes included
+// ---------------------------------------------------------------------------
+
+describe('beforeAgentStart — with nodes', () => {
+  it('includes relevant nodes in prependContext', async () => {
+    const nodeMd = `---
+id: omg/typescript-types
+description: TypeScript type system overview
+type: fact
+priority: high
+created: 2026-01-01T00:00:00Z
+updated: 2026-01-01T00:00:00Z
+---
+TypeScript adds static types to JavaScript for better tooling.
+`
+    vol.fromJSON({
+      [`${OMG_ROOT}/index.md`]: INDEX_MD,
+      [`${OMG_ROOT}/nodes/fact/fact-typescript-2026-01-01.md`]: nodeMd,
+    })
+
+    const config = parseConfig({})
+    const result = await beforeAgentStart(
+      { prompt: 'Tell me about TypeScript types.' },
+      { workspaceDir: WORKSPACE, sessionKey: SESSION_KEY, config }
+    )
+
+    expect(result?.prependContext).toContain('TypeScript')
+  })
+})

--- a/tests/unit/context-renderer.test.ts
+++ b/tests/unit/context-renderer.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest'
+import { renderContextBlock } from '../../src/context/renderer.js'
+import type { GraphContextSlice, GraphNode } from '../../src/types.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeNode(id: string, body: string, type: GraphNode['frontmatter']['type'] = 'fact'): GraphNode {
+  const now = new Date().toISOString()
+  return {
+    frontmatter: {
+      id,
+      description: `Description of ${id}`,
+      type,
+      priority: 'medium',
+      created: now,
+      updated: now,
+    },
+    body,
+    filePath: `/omg/nodes/${type}/${id}.md`,
+  }
+}
+
+function makeSlice(overrides: Partial<GraphContextSlice> = {}): GraphContextSlice {
+  return {
+    index: overrides.index ?? '# Index\n- [[omg/moc-projects]]',
+    nowNode: overrides.nowNode ?? null,
+    mocs: overrides.mocs ?? [],
+    nodes: overrides.nodes ?? [],
+    estimatedTokens: overrides.estimatedTokens ?? 100,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// renderContextBlock
+// ---------------------------------------------------------------------------
+
+describe('renderContextBlock', () => {
+  it('wraps output in <omg-context> tags', () => {
+    const result = renderContextBlock(makeSlice())
+    expect(result).toMatch(/^<omg-context>/)
+    expect(result).toMatch(/<\/omg-context>$/)
+  })
+
+  it('includes Memory Index section with index content', () => {
+    const slice = makeSlice({ index: '# Index\n- [[omg/moc-projects]]' })
+    const result = renderContextBlock(slice)
+    expect(result).toContain('## Memory Index')
+    expect(result).toContain('# Index')
+    expect(result).toContain('[[omg/moc-projects]]')
+  })
+
+  it('includes Current State section when nowNode is present', () => {
+    const now = makeNode('omg/now', '# Now\nWorking on phase 4.', 'now')
+    const slice = makeSlice({ nowNode: now })
+    const result = renderContextBlock(slice)
+    expect(result).toContain('## Current State')
+    expect(result).toContain('Working on phase 4.')
+  })
+
+  it('omits Current State section when nowNode is null', () => {
+    const slice = makeSlice({ nowNode: null })
+    const result = renderContextBlock(slice)
+    expect(result).not.toContain('## Current State')
+  })
+
+  it('includes Relevant Knowledge section with moc and node content', () => {
+    const moc = makeNode('omg/moc/projects', '- [[omg/project/alpha]]', 'moc')
+    const node = makeNode('omg/fact/typescript', 'TypeScript is typed JS.', 'fact')
+    const slice = makeSlice({ mocs: [moc], nodes: [node] })
+    const result = renderContextBlock(slice)
+    expect(result).toContain('## Relevant Knowledge')
+    expect(result).toContain('omg/moc/projects')
+    expect(result).toContain('TypeScript is typed JS.')
+  })
+
+  it('omits Relevant Knowledge section when mocs and nodes are both empty', () => {
+    const slice = makeSlice({ mocs: [], nodes: [] })
+    const result = renderContextBlock(slice)
+    expect(result).not.toContain('## Relevant Knowledge')
+  })
+
+  it('includes node description in rendered output', () => {
+    const node = makeNode('omg/fact/typescript', 'TypeScript is typed JS.', 'fact')
+    node.frontmatter
+    const slice = makeSlice({ nodes: [node] })
+    const result = renderContextBlock(slice)
+    expect(result).toContain('Description of omg/fact/typescript')
+  })
+
+  it('renders multiple nodes in order', () => {
+    const nodeA = makeNode('omg/fact/alpha', 'Alpha content.')
+    const nodeB = makeNode('omg/fact/beta', 'Beta content.')
+    const slice = makeSlice({ nodes: [nodeA, nodeB] })
+    const result = renderContextBlock(slice)
+    const posA = result.indexOf('Alpha content.')
+    const posB = result.indexOf('Beta content.')
+    expect(posA).toBeLessThan(posB)
+  })
+
+  it('minimal slice (only index, no now/mocs/nodes) produces valid output', () => {
+    const slice = makeSlice({ index: '# Index', mocs: [], nodes: [], nowNode: null })
+    const result = renderContextBlock(slice)
+    expect(result).toContain('<omg-context>')
+    expect(result).toContain('## Memory Index')
+    expect(result).not.toContain('## Current State')
+    expect(result).not.toContain('## Relevant Knowledge')
+  })
+})

--- a/tests/unit/context-selector.test.ts
+++ b/tests/unit/context-selector.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { parseConfig } from '../../src/config.js'
+import { selectContext } from '../../src/context/selector.js'
+import type { OmgConfig } from '../../src/config.js'
+import type { GraphNode } from '../../src/types.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeNode(
+  overrides: Partial<{
+    id: string
+    type: GraphNode['frontmatter']['type']
+    priority: GraphNode['frontmatter']['priority']
+    description: string
+    body: string
+    updated: string
+    links: string[]
+    tags: string[]
+  }> = {}
+): GraphNode {
+  const now = new Date().toISOString()
+  return {
+    frontmatter: {
+      id: overrides.id ?? 'omg/fact/test-fact',
+      description: overrides.description ?? 'A test fact',
+      type: overrides.type ?? 'fact',
+      priority: overrides.priority ?? 'medium',
+      created: now,
+      updated: overrides.updated ?? now,
+      links: overrides.links,
+      tags: overrides.tags,
+    },
+    body: overrides.body ?? 'Some content about the topic.',
+    filePath: `/omg/nodes/fact/test-fact.md`,
+  }
+}
+
+function makeOldNode(daysAgo: number, id: string, priority: GraphNode['frontmatter']['priority'] = 'medium'): GraphNode {
+  const d = new Date()
+  d.setDate(d.getDate() - daysAgo)
+  return makeNode({ id, priority, updated: d.toISOString() })
+}
+
+const INDEX_CONTENT = '# Memory Index\n- [[omg/moc-projects]]\n- [[omg/moc-preferences]]'
+const NOW_CONTENT = '# Now\nWorking on phase 4 implementation.'
+
+let config: OmgConfig
+
+beforeEach(() => {
+  config = parseConfig({})
+})
+
+// ---------------------------------------------------------------------------
+// selectContext — empty graph
+// ---------------------------------------------------------------------------
+
+describe('selectContext — empty graph', () => {
+  it('returns index and nowNode when graph has no nodes or mocs', () => {
+    const slice = selectContext({
+      indexContent: INDEX_CONTENT,
+      nowContent: NOW_CONTENT,
+      allNodes: [],
+      recentMessages: [],
+      config,
+    })
+
+    expect(slice.index).toBe(INDEX_CONTENT)
+    expect(slice.nowNode).not.toBeNull()
+    expect(slice.nodes).toHaveLength(0)
+    expect(slice.mocs).toHaveLength(0)
+  })
+
+  it('returns null nowNode when nowContent is null', () => {
+    const slice = selectContext({
+      indexContent: INDEX_CONTENT,
+      nowContent: null,
+      allNodes: [],
+      recentMessages: [],
+      config,
+    })
+
+    expect(slice.nowNode).toBeNull()
+  })
+
+  it('estimates tokens for index + now', () => {
+    const slice = selectContext({
+      indexContent: INDEX_CONTENT,
+      nowContent: NOW_CONTENT,
+      allNodes: [],
+      recentMessages: [],
+      config,
+    })
+
+    expect(slice.estimatedTokens).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// selectContext — node scoring
+// ---------------------------------------------------------------------------
+
+describe('selectContext — node scoring', () => {
+  it('includes high-priority nodes before low-priority ones when budget is tight', () => {
+    const tightConfig = parseConfig({ injection: { maxContextTokens: 100, maxNodes: 2 } })
+
+    const highNode = makeNode({ id: 'omg/fact/high', priority: 'high', body: 'hi' })
+    const lowNode = makeNode({ id: 'omg/fact/low', priority: 'low', body: 'lo' })
+    const medNode = makeNode({ id: 'omg/fact/med', priority: 'medium', body: 'md' })
+
+    const slice = selectContext({
+      indexContent: '',
+      nowContent: null,
+      allNodes: [lowNode, highNode, medNode],
+      recentMessages: [],
+      config: tightConfig,
+    })
+
+    const ids = slice.nodes.map((n) => n.frontmatter.id)
+    expect(ids).toContain('omg/fact/high')
+  })
+
+  it('applies recency factor — newer nodes rank higher than older at same priority', () => {
+    const newNode = makeOldNode(1, 'omg/fact/new', 'medium')
+    const oldNode = makeOldNode(60, 'omg/fact/old', 'medium')
+
+    const tightConfig = parseConfig({ injection: { maxContextTokens: 50, maxNodes: 1 } })
+
+    const slice = selectContext({
+      indexContent: '',
+      nowContent: null,
+      allNodes: [oldNode, newNode],
+      recentMessages: [],
+      config: tightConfig,
+    })
+
+    const ids = slice.nodes.map((n) => n.frontmatter.id)
+    expect(ids).toContain('omg/fact/new')
+    expect(ids).not.toContain('omg/fact/old')
+  })
+
+  it('boosts nodes that match keywords in recent messages', () => {
+    const relevantNode = makeNode({ id: 'omg/fact/typescript', body: 'TypeScript configuration matters.', tags: ['typescript'] })
+    const irrelevantNode = makeNode({ id: 'omg/fact/cooking', body: 'Pasta recipe for dinner.', tags: ['food'] })
+
+    const tightConfig = parseConfig({ injection: { maxContextTokens: 80, maxNodes: 1 } })
+
+    const slice = selectContext({
+      indexContent: '',
+      nowContent: null,
+      allNodes: [irrelevantNode, relevantNode],
+      recentMessages: [{ role: 'user', content: 'Help me with TypeScript configuration.' }],
+      config: tightConfig,
+    })
+
+    const ids = slice.nodes.map((n) => n.frontmatter.id)
+    expect(ids).toContain('omg/fact/typescript')
+    expect(ids).not.toContain('omg/fact/cooking')
+  })
+
+  it('respects maxNodes limit', () => {
+    const nodes = Array.from({ length: 10 }, (_, i) =>
+      makeNode({ id: `omg/fact/node-${i}`, body: 'content ' + i })
+    )
+
+    const limitedConfig = parseConfig({ injection: { maxNodes: 3, maxContextTokens: 10_000 } })
+
+    const slice = selectContext({
+      indexContent: '',
+      nowContent: null,
+      allNodes: nodes,
+      recentMessages: [],
+      config: limitedConfig,
+    })
+
+    expect(slice.nodes.length).toBeLessThanOrEqual(3)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// selectContext — MOC handling
+// ---------------------------------------------------------------------------
+
+describe('selectContext — MOC handling', () => {
+  it('separates moc nodes from regular nodes', () => {
+    const mocNode = makeNode({ id: 'omg/moc/projects', type: 'moc', body: '- [[omg/project/alpha]]' })
+    const factNode = makeNode({ id: 'omg/fact/alpha', type: 'fact' })
+
+    const slice = selectContext({
+      indexContent: '',
+      nowContent: null,
+      allNodes: [mocNode, factNode],
+      recentMessages: [],
+      config,
+    })
+
+    expect(slice.mocs.map((m) => m.frontmatter.id)).toContain('omg/moc/projects')
+    expect(slice.nodes.map((n) => n.frontmatter.id)).toContain('omg/fact/alpha')
+    expect(slice.nodes.map((n) => n.frontmatter.id)).not.toContain('omg/moc/projects')
+  })
+
+  it('respects maxMocs limit', () => {
+    const mocs = Array.from({ length: 6 }, (_, i) =>
+      makeNode({ id: `omg/moc/domain-${i}`, type: 'moc', body: `- [[omg/fact/node-${i}]]` })
+    )
+
+    const limitedConfig = parseConfig({ injection: { maxMocs: 2, maxContextTokens: 10_000 } })
+
+    const slice = selectContext({
+      indexContent: '',
+      nowContent: null,
+      allNodes: mocs,
+      recentMessages: [],
+      config: limitedConfig,
+    })
+
+    expect(slice.mocs.length).toBeLessThanOrEqual(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// selectContext — pinned nodes
+// ---------------------------------------------------------------------------
+
+describe('selectContext — pinned nodes', () => {
+  it('always includes pinned nodes regardless of score', () => {
+    // Pinned node IDs use two-segment format as required by config validation
+    const pinnedNode = makeNode({ id: 'omg/identity-core', type: 'identity', priority: 'low', body: 'core identity' })
+    const highNode = makeNode({ id: 'omg/fact-other', priority: 'high', body: 'other stuff' })
+
+    const pinnedConfig = parseConfig({
+      injection: {
+        maxNodes: 1,
+        maxContextTokens: 10_000,
+        pinnedNodes: ['omg/identity-core'],
+      },
+    })
+
+    const slice = selectContext({
+      indexContent: '',
+      nowContent: null,
+      allNodes: [highNode, pinnedNode],
+      recentMessages: [],
+      config: pinnedConfig,
+    })
+
+    const ids = slice.nodes.map((n) => n.frontmatter.id)
+    expect(ids).toContain('omg/identity-core')
+  })
+
+  it('does not double-include a pinned node that is also top-ranked', () => {
+    const pinnedNode = makeNode({ id: 'omg/fact-top', priority: 'high', body: 'top fact' })
+
+    const pinnedConfig = parseConfig({
+      injection: { maxNodes: 5, maxContextTokens: 10_000, pinnedNodes: ['omg/fact-top'] },
+    })
+
+    const slice = selectContext({
+      indexContent: '',
+      nowContent: null,
+      allNodes: [pinnedNode],
+      recentMessages: [],
+      config: pinnedConfig,
+    })
+
+    const ids = slice.nodes.map((n) => n.frontmatter.id)
+    const count = ids.filter((id) => id === 'omg/fact-top').length
+    expect(count).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// selectContext — token budget
+// ---------------------------------------------------------------------------
+
+describe('selectContext — token budget', () => {
+  it('enforces maxContextTokens and drops lowest-scored nodes first', () => {
+    // Each body word ~= 0.25 tokens. Make bodies large enough to matter.
+    const makeBodyNode = (id: string, priority: GraphNode['frontmatter']['priority'], bodyLength: number) =>
+      makeNode({ id, priority, body: 'w'.repeat(bodyLength) })
+
+    const highNode = makeBodyNode('omg/fact/high', 'high', 20)
+    const lowNode = makeBodyNode('omg/fact/low', 'low', 20)
+
+    // Budget tight enough that we can fit only one
+    const tightConfig = parseConfig({ injection: { maxContextTokens: 10, maxNodes: 10 } })
+
+    const slice = selectContext({
+      indexContent: '',
+      nowContent: null,
+      allNodes: [lowNode, highNode],
+      recentMessages: [],
+      config: tightConfig,
+    })
+
+    const ids = slice.nodes.map((n) => n.frontmatter.id)
+    if (ids.length > 0) {
+      expect(ids).not.toContain('omg/fact/low')
+    }
+  })
+
+  it('estimatedTokens does not exceed maxContextTokens significantly', () => {
+    const nodes = Array.from({ length: 20 }, (_, i) =>
+      makeNode({ id: `omg/fact/node-${i}`, body: 'x'.repeat(400) }) // ~100 tokens each
+    )
+
+    const tightConfig = parseConfig({ injection: { maxContextTokens: 500, maxNodes: 20 } })
+
+    const slice = selectContext({
+      indexContent: '',
+      nowContent: null,
+      allNodes: nodes,
+      recentMessages: [],
+      config: tightConfig,
+    })
+
+    // Estimated tokens should be within budget (may slightly exceed due to estimation heuristic)
+    expect(slice.estimatedTokens).toBeLessThanOrEqual(600)
+  })
+})

--- a/tests/unit/plugin.test.ts
+++ b/tests/unit/plugin.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { PluginApi } from '../../src/plugin.js'
+
+vi.mock('../../src/hooks/agent-end.js', () => ({
+  agentEnd: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('../../src/hooks/before-agent-start.js', () => ({
+  beforeAgentStart: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('../../src/hooks/tool-result-persist.js', () => ({
+  toolResultPersist: vi.fn().mockReturnValue(undefined),
+}))
+vi.mock('../../src/llm/client.js', () => ({
+  createLlmClient: vi.fn().mockReturnValue({ generate: vi.fn() }),
+}))
+
+const { register } = await import('../../src/plugin.js')
+
+function makeMockApi(config: Record<string, unknown> = {}): PluginApi & { on: ReturnType<typeof vi.fn> } {
+  return {
+    config,
+    workspaceDir: '/workspace',
+    generate: vi.fn(),
+    on: vi.fn(),
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// register — hook wiring
+// ---------------------------------------------------------------------------
+
+describe('register — hook registration', () => {
+  it('registers exactly three hooks', () => {
+    const api = makeMockApi()
+    register(api)
+    expect(api.on).toHaveBeenCalledTimes(3)
+  })
+
+  it('registers before_agent_start hook', () => {
+    const api = makeMockApi()
+    register(api)
+    expect(api.on).toHaveBeenCalledWith('before_agent_start', expect.any(Function))
+  })
+
+  it('registers agent_end hook', () => {
+    const api = makeMockApi()
+    register(api)
+    expect(api.on).toHaveBeenCalledWith('agent_end', expect.any(Function))
+  })
+
+  it('registers tool_result_persist hook', () => {
+    const api = makeMockApi()
+    register(api)
+    expect(api.on).toHaveBeenCalledWith('tool_result_persist', expect.any(Function))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// register — config validation
+// ---------------------------------------------------------------------------
+
+describe('register — config validation', () => {
+  it('succeeds with valid empty config (all defaults)', () => {
+    const api = makeMockApi({})
+    expect(() => register(api)).not.toThrow()
+  })
+
+  it('throws when config has an invalid triggerMode', () => {
+    const api = makeMockApi({ observation: { triggerMode: 'not-a-valid-mode' } })
+    expect(() => register(api)).toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// register — default export
+// ---------------------------------------------------------------------------
+
+describe('register — default export', () => {
+  it('default export equals named register export', async () => {
+    const mod = await import('../../src/plugin.js')
+    expect(mod.default).toBe(mod.register)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// register — agent_end handler argument forwarding
+// ---------------------------------------------------------------------------
+
+describe('register — agent_end handler', () => {
+  it('forwards ctx.messages to agentEnd', async () => {
+    const { agentEnd } = await import('../../src/hooks/agent-end.js')
+    const api = makeMockApi()
+    register(api)
+
+    const agentEndCall = (api.on as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call) => call[0] === 'agent_end'
+    )
+    const handler = agentEndCall![1] as (
+      event: { success: boolean },
+      ctx: { sessionKey: string; messages: Array<{ role: string; content: string }> }
+    ) => Promise<void>
+
+    const messages = [{ role: 'user' as const, content: 'Hello' }]
+    await handler({ success: true }, { sessionKey: 'test-session', messages })
+
+    expect(agentEnd).toHaveBeenCalledWith(
+      { success: true },
+      expect.objectContaining({ messages })
+    )
+  })
+})

--- a/tests/unit/session-state.test.ts
+++ b/tests/unit/session-state.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { vi } from 'vitest'
+import { vol } from 'memfs'
+import { loadSessionState, saveSessionState, getDefaultSessionState } from '../../src/state/session-state.js'
+import type { OmgSessionState } from '../../src/types.js'
+
+vi.mock('node:fs', async () => {
+  const m = await vi.importActual<typeof import('memfs')>('memfs')
+  return { default: m.fs, ...m.fs }
+})
+vi.mock('node:fs/promises', async () => {
+  const m = await vi.importActual<typeof import('memfs')>('memfs')
+  return { default: m.fs.promises, ...m.fs.promises }
+})
+
+const WORKSPACE = '/workspace'
+const SESSION_KEY = 'session-abc123'
+const STATE_PATH = `${WORKSPACE}/.omg-state/${SESSION_KEY}.json`
+
+function validState(): OmgSessionState {
+  return {
+    lastObservedAtMs: 1_000_000,
+    pendingMessageTokens: 500,
+    totalObservationTokens: 3000,
+    observationBoundaryMessageIndex: 5,
+    nodeCount: 12,
+    lastObservationNodeIds: ['omg/fact/alpha', 'omg/fact/beta'],
+  }
+}
+
+beforeEach(() => {
+  vol.reset()
+})
+
+// ---------------------------------------------------------------------------
+// getDefaultSessionState
+// ---------------------------------------------------------------------------
+
+describe('getDefaultSessionState', () => {
+  it('returns all-zero numeric fields', () => {
+    const state = getDefaultSessionState()
+    expect(state.lastObservedAtMs).toBe(0)
+    expect(state.pendingMessageTokens).toBe(0)
+    expect(state.totalObservationTokens).toBe(0)
+    expect(state.observationBoundaryMessageIndex).toBe(0)
+    expect(state.nodeCount).toBe(0)
+  })
+
+  it('returns empty lastObservationNodeIds array', () => {
+    const state = getDefaultSessionState()
+    expect(state.lastObservationNodeIds).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// loadSessionState — missing file
+// ---------------------------------------------------------------------------
+
+describe('loadSessionState — missing file', () => {
+  it('returns default state when file does not exist', async () => {
+    const state = await loadSessionState(WORKSPACE, SESSION_KEY)
+    const defaults = getDefaultSessionState()
+    expect(state).toEqual(defaults)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// saveSessionState + loadSessionState — round-trip
+// ---------------------------------------------------------------------------
+
+describe('saveSessionState + loadSessionState', () => {
+  it('round-trips state correctly', async () => {
+    const original = validState()
+    await saveSessionState(WORKSPACE, SESSION_KEY, original)
+    const loaded = await loadSessionState(WORKSPACE, SESSION_KEY)
+    expect(loaded).toEqual(original)
+  })
+
+  it('creates .omg-state directory if it does not exist', async () => {
+    await saveSessionState(WORKSPACE, SESSION_KEY, validState())
+    const { fs } = await import('memfs')
+    expect(fs.existsSync(STATE_PATH)).toBe(true)
+  })
+
+  it('overwrites existing state on subsequent saves', async () => {
+    await saveSessionState(WORKSPACE, SESSION_KEY, validState())
+    const updated: OmgSessionState = {
+      ...validState(),
+      pendingMessageTokens: 9999,
+      nodeCount: 99,
+    }
+    await saveSessionState(WORKSPACE, SESSION_KEY, updated)
+    const loaded = await loadSessionState(WORKSPACE, SESSION_KEY)
+    expect(loaded.pendingMessageTokens).toBe(9999)
+    expect(loaded.nodeCount).toBe(99)
+  })
+
+  it('persists lastObservationNodeIds correctly', async () => {
+    const state: OmgSessionState = { ...validState(), lastObservationNodeIds: ['omg/fact/node-1', 'omg/fact/node-2'] }
+    await saveSessionState(WORKSPACE, SESSION_KEY, state)
+    const loaded = await loadSessionState(WORKSPACE, SESSION_KEY)
+    expect(loaded.lastObservationNodeIds).toEqual(['omg/fact/node-1', 'omg/fact/node-2'])
+  })
+
+  it('isolates state per sessionKey', async () => {
+    const stateA: OmgSessionState = { ...validState(), nodeCount: 1 }
+    const stateB: OmgSessionState = { ...validState(), nodeCount: 2 }
+    await saveSessionState(WORKSPACE, 'session-a', stateA)
+    await saveSessionState(WORKSPACE, 'session-b', stateB)
+    const loadedA = await loadSessionState(WORKSPACE, 'session-a')
+    const loadedB = await loadSessionState(WORKSPACE, 'session-b')
+    expect(loadedA.nodeCount).toBe(1)
+    expect(loadedB.nodeCount).toBe(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// loadSessionState — invalid JSON graceful recovery
+// ---------------------------------------------------------------------------
+
+describe('loadSessionState — invalid JSON', () => {
+  it('returns default state when file contains invalid JSON', async () => {
+    vol.fromJSON({ [STATE_PATH]: 'not valid json {{{{' })
+    const state = await loadSessionState(WORKSPACE, SESSION_KEY)
+    expect(state).toEqual(getDefaultSessionState())
+  })
+
+  it('returns default state when file is empty', async () => {
+    vol.fromJSON({ [STATE_PATH]: '' })
+    const state = await loadSessionState(WORKSPACE, SESSION_KEY)
+    expect(state).toEqual(getDefaultSessionState())
+  })
+})

--- a/tests/unit/token-tracker.test.ts
+++ b/tests/unit/token-tracker.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest'
+import { parseConfig } from '../../src/config.js'
+import { accumulateTokens, shouldTriggerObservation, shouldTriggerReflection } from '../../src/state/token-tracker.js'
+import type { OmgSessionState, Message } from '../../src/types.js'
+
+function defaultState(overrides: Partial<OmgSessionState> = {}): OmgSessionState {
+  return {
+    lastObservedAtMs: 0,
+    pendingMessageTokens: 0,
+    totalObservationTokens: 0,
+    observationBoundaryMessageIndex: 0,
+    nodeCount: 0,
+    lastObservationNodeIds: [],
+    ...overrides,
+  }
+}
+
+const MSG = (content: string): Message => ({ role: 'user', content })
+
+// ---------------------------------------------------------------------------
+// accumulateTokens
+// ---------------------------------------------------------------------------
+
+describe('accumulateTokens', () => {
+  it('accumulates tokens from messages after the boundary index', () => {
+    const messages: Message[] = [
+      MSG('old message'),   // index 0 — already observed
+      MSG('new message 1'), // index 1 — not yet observed
+      MSG('new message 2'), // index 2 — not yet observed
+    ]
+    const state = defaultState({ observationBoundaryMessageIndex: 1 })
+    const next = accumulateTokens(messages, state)
+    // 'new message 1' + 'new message 2' = 26 chars ≈ 7 tokens
+    expect(next.pendingMessageTokens).toBeGreaterThan(0)
+  })
+
+  it('does not mutate the original state', () => {
+    const state = defaultState({ pendingMessageTokens: 100 })
+    const messages: Message[] = [MSG('hello')]
+    accumulateTokens(messages, state)
+    expect(state.pendingMessageTokens).toBe(100)
+  })
+
+  it('returns a new state object', () => {
+    const state = defaultState()
+    const next = accumulateTokens([MSG('hi')], state)
+    expect(next).not.toBe(state)
+  })
+
+  it('accumulates tokens from 3 messages correctly', () => {
+    const messages: Message[] = [
+      MSG('a'.repeat(40)),  // 10 tokens
+      MSG('b'.repeat(40)),  // 10 tokens
+      MSG('c'.repeat(40)),  // 10 tokens
+    ]
+    const state = defaultState({ observationBoundaryMessageIndex: 0 })
+    const next = accumulateTokens(messages, state)
+    expect(next.pendingMessageTokens).toBe(30)
+  })
+
+  it('replaces pendingMessageTokens with a fresh recalculation (no double-counting)', () => {
+    // Any previously saved pendingMessageTokens must be discarded; only the
+    // current messages from the boundary onward should count.
+    const messages: Message[] = [MSG('a'.repeat(40))]
+    const state = defaultState({ pendingMessageTokens: 50, observationBoundaryMessageIndex: 0 })
+    const next = accumulateTokens(messages, state)
+    expect(next.pendingMessageTokens).toBe(10) // 40 chars ≈ 10 tokens; 50 is NOT added
+  })
+
+  it('returns same pending count when no new messages since boundary', () => {
+    const messages: Message[] = [MSG('already observed')]
+    const state = defaultState({
+      pendingMessageTokens: 0,
+      observationBoundaryMessageIndex: 1, // boundary is past all messages
+    })
+    const next = accumulateTokens(messages, state)
+    expect(next.pendingMessageTokens).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// shouldTriggerObservation
+// ---------------------------------------------------------------------------
+
+describe('shouldTriggerObservation', () => {
+  it('every-turn mode always returns true', () => {
+    const config = parseConfig({ observation: { triggerMode: 'every-turn' } })
+    const state = defaultState({ pendingMessageTokens: 0 })
+    expect(shouldTriggerObservation(state, config)).toBe(true)
+  })
+
+  it('manual mode always returns false', () => {
+    const config = parseConfig({ observation: { triggerMode: 'manual' } })
+    const state = defaultState({ pendingMessageTokens: 999_999 })
+    expect(shouldTriggerObservation(state, config)).toBe(false)
+  })
+
+  it('threshold mode returns false when below threshold', () => {
+    const config = parseConfig({ observation: { triggerMode: 'threshold', messageTokenThreshold: 1000 } })
+    const state = defaultState({ pendingMessageTokens: 500 })
+    expect(shouldTriggerObservation(state, config)).toBe(false)
+  })
+
+  it('threshold mode returns true when at threshold', () => {
+    const config = parseConfig({ observation: { triggerMode: 'threshold', messageTokenThreshold: 1000 } })
+    const state = defaultState({ pendingMessageTokens: 1000 })
+    expect(shouldTriggerObservation(state, config)).toBe(true)
+  })
+
+  it('threshold mode returns true when above threshold', () => {
+    const config = parseConfig({ observation: { triggerMode: 'threshold', messageTokenThreshold: 1000 } })
+    const state = defaultState({ pendingMessageTokens: 1500 })
+    expect(shouldTriggerObservation(state, config)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// shouldTriggerReflection
+// ---------------------------------------------------------------------------
+
+describe('shouldTriggerReflection', () => {
+  it('returns false when below threshold', () => {
+    const config = parseConfig({ reflection: { observationTokenThreshold: 40_000 } })
+    const state = defaultState({ totalObservationTokens: 10_000 })
+    expect(shouldTriggerReflection(state, config)).toBe(false)
+  })
+
+  it('returns true when at threshold', () => {
+    const config = parseConfig({ reflection: { observationTokenThreshold: 40_000 } })
+    const state = defaultState({ totalObservationTokens: 40_000 })
+    expect(shouldTriggerReflection(state, config)).toBe(true)
+  })
+
+  it('returns true when above threshold', () => {
+    const config = parseConfig({ reflection: { observationTokenThreshold: 40_000 } })
+    const state = defaultState({ totalObservationTokens: 50_000 })
+    expect(shouldTriggerReflection(state, config)).toBe(true)
+  })
+})

--- a/tests/unit/tool-result-persist.test.ts
+++ b/tests/unit/tool-result-persist.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import { toolResultPersist } from '../../src/hooks/tool-result-persist.js'
+
+// ---------------------------------------------------------------------------
+// toolResultPersist — synchronous hook
+// ---------------------------------------------------------------------------
+
+describe('toolResultPersist — memory_search tool', () => {
+  it('extracts omg/ node references from memory_search result text', () => {
+    const event = {
+      toolName: 'memory_search',
+      result: {
+        content: [{ type: 'text', text: 'Found nodes: omg/fact/typescript-types and omg/preference/editor-dark-mode' }],
+      },
+    }
+
+    const tagged = toolResultPersist(event)
+
+    expect(tagged).toBeDefined()
+    expect(tagged?.referencedNodeIds).toContain('omg/fact/typescript-types')
+    expect(tagged?.referencedNodeIds).toContain('omg/preference/editor-dark-mode')
+  })
+
+  it('returns empty referencedNodeIds when result has no omg/ paths', () => {
+    const event = {
+      toolName: 'memory_search',
+      result: {
+        content: [{ type: 'text', text: 'No relevant memories found.' }],
+      },
+    }
+
+    const tagged = toolResultPersist(event)
+    expect(tagged?.referencedNodeIds).toEqual([])
+  })
+
+  it('handles result with multiple omg/ references across content blocks', () => {
+    const event = {
+      toolName: 'memory_search',
+      result: {
+        content: [
+          { type: 'text', text: 'Reference: omg/identity/user-profile' },
+          { type: 'text', text: 'Also: omg/project/main-app' },
+        ],
+      },
+    }
+
+    const tagged = toolResultPersist(event)
+    expect(tagged?.referencedNodeIds).toContain('omg/identity/user-profile')
+    expect(tagged?.referencedNodeIds).toContain('omg/project/main-app')
+  })
+
+  it('deduplicates repeated node references', () => {
+    const event = {
+      toolName: 'memory_search',
+      result: {
+        content: [{ type: 'text', text: 'omg/fact/typescript-types omg/fact/typescript-types' }],
+      },
+    }
+
+    const tagged = toolResultPersist(event)
+    const count = tagged?.referencedNodeIds.filter((id) => id === 'omg/fact/typescript-types').length
+    expect(count).toBe(1)
+  })
+})
+
+describe('toolResultPersist — non-memory_search tools', () => {
+  it('returns undefined for bash tool', () => {
+    const event = { toolName: 'bash', result: { output: 'hello world' } }
+    expect(toolResultPersist(event)).toBeUndefined()
+  })
+
+  it('returns undefined for web_fetch tool', () => {
+    const event = { toolName: 'web_fetch', result: { content: 'omg/fact/something' } }
+    expect(toolResultPersist(event)).toBeUndefined()
+  })
+
+  it('returns undefined for read_file tool even if result contains omg/ paths', () => {
+    const event = {
+      toolName: 'read_file',
+      result: { content: 'omg/fact/typescript-types referenced here' },
+    }
+    expect(toolResultPersist(event)).toBeUndefined()
+  })
+})
+
+describe('toolResultPersist — error resilience', () => {
+  it('never throws for malformed result', () => {
+    const event = { toolName: 'memory_search', result: null }
+    expect(() => toolResultPersist(event)).not.toThrow()
+  })
+
+  it('never throws for missing result content', () => {
+    const event = { toolName: 'memory_search', result: {} }
+    expect(() => toolResultPersist(event)).not.toThrow()
+  })
+
+  it('never throws for undefined result', () => {
+    const event = { toolName: 'memory_search', result: undefined }
+    expect(() => toolResultPersist(event)).not.toThrow()
+  })
+})

--- a/tests/unit/types.test.ts
+++ b/tests/unit/types.test.ts
@@ -247,6 +247,7 @@ describe('createOmgSessionState', () => {
     totalObservationTokens: 10_000,
     observationBoundaryMessageIndex: 42,
     nodeCount: 15,
+    lastObservationNodeIds: [] as readonly string[],
   }
 
   it('returns the validated state for all-positive fields', () => {
@@ -260,6 +261,7 @@ describe('createOmgSessionState', () => {
       totalObservationTokens: 0,
       observationBoundaryMessageIndex: 0,
       nodeCount: 0,
+      lastObservationNodeIds: [],
     })
     expect(state.lastObservedAtMs).toBe(0)
     expect(state.totalObservationTokens).toBe(0)


### PR DESCRIPTION
## Summary

- **`src/hooks/agent-end.ts`** — full observation cycle: LLM call → node writes (partial-write safe via `Promise.allSettled`) → MOC updates → state persistence. Never throws.
- **`src/hooks/before-agent-start.ts`** — injects `<omg-context>` block into agent prompt via budget-aware node selection
- **`src/hooks/tool-result-persist.ts`** — tags referenced node IDs on `memory_search` tool results
- **`src/context/selector.ts`** — scores and selects nodes within token budget (recency, priority, keyword match)
- **`src/context/renderer.ts`** — renders selected context slice to structured XML block
- **`src/state/session-state.ts`** — atomic load/save of per-session state
- **`src/state/token-tracker.ts`** — token accumulation and observation/reflection trigger logic
- **`src/plugin.ts`** — `register()` entry point wiring all three hooks to the OpenClaw API

Type/config changes: `+lastObservationNodeIds` on `OmgSessionState`, `+'every-turn'` trigger mode, `+readFileOrNull` fs utility.

## PR review

Two-round review completed (CLAUDE.md rules). Round 1 found 3 blockers, all fixed before commit:
- TS2769 type error in `plugin.test.ts` find() predicate
- `createOmgSessionState()` could throw outside all try blocks (never-throws contract violated)
- `Promise.all` for node writes caused partial-write orphaning on failure → replaced with `Promise.allSettled`

Round 2: LGTM, 0 new blockers.

## Debt tracked

| Issue | Description |
|-------|-------------|
| #33 | `before-agent-start` broad catch swallows permanent I/O errors |
| #34 | `persistState` swallows ENOSPC/EROFS without actionable guidance |
| #35 | `console.error` for Phase 5 placeholder → Sentry noise |
| #36 | `plugin.register()` exposes raw `ConfigValidationError` |
| #37 | Negative context budget silently drops all nodes |
| #38 | `computeRecencyFactor` error log missing node ID |
| #39 | `loadSessionState` catch conflates JSON errors with code bugs |
| #40 | Test coverage gaps (4 modules, 7 missing cases) |

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 533/533 pass
- [ ] Smoke test with real OpenClaw session against a populated graph
- [ ] Verify `every-turn` trigger mode in dev environment
- [ ] Confirm `<omg-context>` block appears in agent system prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)