### PR TITLE
feat: bounded, resumable, restart-proof bootstrap via cron

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -475,6 +475,24 @@ const bootstrapSchema = z
       .int()
       .min(0, 'batchCharBudget must be >= 0')
       .default(24_000),
+    /**
+     * Maximum number of batches processed per cron tick.
+     * Controls the token budget per bootstrap tick — the cron handler processes
+     * at most this many batches, then pauses until the next tick.
+     * Only used by `runBootstrapTick`; `runBootstrap` (CLI `--force`) ignores this.
+     * @default 20
+     */
+    batchBudgetPerRun: z
+      .number()
+      .int()
+      .positive('batchBudgetPerRun must be a positive integer')
+      .default(20),
+    /**
+     * 5-field cron schedule for the bootstrap cron job.
+     * Example: `*​/5 * * * *` runs every 5 minutes.
+     * @default '*​/5 * * * *'
+     */
+    cronSchedule: cronField.default('*/5 * * * *'),
   })
   .strip()
 

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -921,3 +921,59 @@ describe('parseConfig — graphMaintenance', () => {
     expect(result.graphMaintenance.cronSchedule).toBe(result.reflection.cronSchedule)
   })
 })
+
+// ---------------------------------------------------------------------------
+// bootstrap.batchBudgetPerRun & bootstrap.cronSchedule
+// ---------------------------------------------------------------------------
+
+describe('parseConfig — bootstrap.batchBudgetPerRun', () => {
+  it('defaults to 20', () => {
+    const result = parseConfig({})
+    expect(result.bootstrap.batchBudgetPerRun).toBe(20)
+  })
+
+  it('accepts a positive integer', () => {
+    const result = parseConfig({ bootstrap: { batchBudgetPerRun: 5 } })
+    expect(result.bootstrap.batchBudgetPerRun).toBe(5)
+  })
+
+  it('rejects zero', () => {
+    expectFieldError(
+      () => parseConfig({ bootstrap: { batchBudgetPerRun: 0 } }),
+      'bootstrap.batchBudgetPerRun'
+    )
+  })
+
+  it('rejects negative values', () => {
+    expectFieldError(
+      () => parseConfig({ bootstrap: { batchBudgetPerRun: -1 } }),
+      'bootstrap.batchBudgetPerRun'
+    )
+  })
+
+  it('rejects non-integer values', () => {
+    expectFieldError(
+      () => parseConfig({ bootstrap: { batchBudgetPerRun: 2.5 } }),
+      'bootstrap.batchBudgetPerRun'
+    )
+  })
+})
+
+describe('parseConfig — bootstrap.cronSchedule', () => {
+  it('defaults to */5 * * * *', () => {
+    const result = parseConfig({})
+    expect(result.bootstrap.cronSchedule).toBe('*/5 * * * *')
+  })
+
+  it('accepts a valid 5-field cron expression', () => {
+    const result = parseConfig({ bootstrap: { cronSchedule: '0 * * * *' } })
+    expect(result.bootstrap.cronSchedule).toBe('0 * * * *')
+  })
+
+  it('rejects an invalid cron expression', () => {
+    expectFieldError(
+      () => parseConfig({ bootstrap: { cronSchedule: 'not-a-cron' } }),
+      'bootstrap.cronSchedule'
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- Bootstrap work is now **scheduled via cron**, not executed inline on startup
- A dedicated `omg-bootstrap` cron job processes a configurable batch budget per tick (`batchBudgetPerRun`, default 20), persists state as `paused` between ticks, and self-disables once complete
- Gateway restarts are fully safe — cron picks up from `paused` state, cursor resumes correctly
- `runBootstrap()` (CLI `--force`) unchanged — processes all batches to completion
- Safety net: when cron is unavailable (old host without `scheduleCron`), `before_prompt_build` runs one bounded tick inline

### Changes

| File | Change |
|------|--------|
| `src/bootstrap/state.ts` | Add `paused` status + `pauseState()` + update `shouldBootstrap` |
| `src/bootstrap/bootstrap.ts` | Add `runBootstrapTick()`, refactor `_runBootstrapLocked` with optional `maxBatches` |
| `src/config.ts` | Add `bootstrap.batchBudgetPerRun` (default 20) + `bootstrap.cronSchedule` (default `*/5 * * * *`) |
| `src/cron/definitions.ts` | Add `bootstrapCronHandler` + `omg-bootstrap` cron definition |
| `src/plugin.ts` | Remove inline bootstrap from `gateway_start` and `before_prompt_build`; add cron-unavailable safety net |

### State transitions

```
              ┌──────────────┐
    null ─────▶   running    ◀─────── paused (resumed)
              │  (tick in    │
              │   progress)  │
              └──────┬───────┘
                     │
         ┌───────────┼───────────┐
         ▼           ▼           ▼
     paused      completed    failed
(budget exhausted, (all done) (rate limit/
 more remain)                  gateway abort)
```

## Test plan

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm test` — 1176 pass, 0 fail (35 new tests)
- [ ] Manual: delete `.bootstrap-state.json`, restart gateway, observe cron fires within 5 min
- [ ] Manual: kill gateway mid-tick, restart — verify resume from `paused` state
- [ ] Manual: `openclaw omg bootstrap --force` still runs full pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)