### PR TITLE
fix: prevent token burn, circuit breaker, batch dedup, remove agent-end reflection

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -35,7 +35,7 @@
         "properties": {
           "messageTokenThreshold": {
             "type": "integer",
-            "minimum": 1,
+            "minimum": 4000,
             "default": 30000,
             "description": "Accumulated token count of unprocessed messages that triggers an observation run"
           },
@@ -52,7 +52,7 @@
         "properties": {
           "observationTokenThreshold": {
             "type": "integer",
-            "minimum": 1,
+            "minimum": 4000,
             "default": 40000,
             "description": "Cumulative observation tokens that triggers a reflection pass"
           },

--- a/src/config.ts
+++ b/src/config.ts
@@ -937,17 +937,23 @@ export function parseConfig(raw: unknown, options: ParseConfigOptions = {}): Omg
   // Would fire observation on every short turn, burning tokens. Clamp to 8000.
   const MIN_SAFE_MESSAGE_THRESHOLD = 1000
   const DEFAULT_MESSAGE_THRESHOLD = 8_000
-  if (result.data.observation.messageTokenThreshold < MIN_SAFE_MESSAGE_THRESHOLD) {
+  let validated = result.data satisfies z.infer<typeof omgConfigSchema>
+  if (validated.observation.messageTokenThreshold < MIN_SAFE_MESSAGE_THRESHOLD) {
     console.warn(
-      `[omg] parseConfig: messageTokenThreshold (${result.data.observation.messageTokenThreshold}) ` +
+      `[omg] parseConfig: messageTokenThreshold (${validated.observation.messageTokenThreshold}) ` +
       `is below minimum safe threshold (${MIN_SAFE_MESSAGE_THRESHOLD}) — clamping to ${DEFAULT_MESSAGE_THRESHOLD}`,
     )
-    ;(result.data.observation as { messageTokenThreshold: number }).messageTokenThreshold = DEFAULT_MESSAGE_THRESHOLD
+    validated = {
+      ...validated,
+      observation: {
+        ...validated.observation,
+        messageTokenThreshold: DEFAULT_MESSAGE_THRESHOLD,
+      },
+    }
   }
 
   // Cast required: z.infer does not add readonly modifiers; OmgConfig wraps the
   // inferred type in DeepReadonly<...>. The satisfies check ensures the inferred
   // schema type and OmgConfig remain aligned at compile time.
-  const validated = result.data satisfies z.infer<typeof omgConfigSchema>
   return validated as OmgConfig
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -932,6 +932,19 @@ export function parseConfig(raw: unknown, options: ParseConfigOptions = {}): Omg
     }
   }
 
+  // Floor clamp: messageTokenThreshold below 1000 is almost certainly a
+  // misconfiguration (e.g. gateway using JSON Schema "minimum" as default).
+  // Would fire observation on every short turn, burning tokens. Clamp to 8000.
+  const MIN_SAFE_MESSAGE_THRESHOLD = 1000
+  const DEFAULT_MESSAGE_THRESHOLD = 8_000
+  if (result.data.observation.messageTokenThreshold < MIN_SAFE_MESSAGE_THRESHOLD) {
+    console.warn(
+      `[omg] parseConfig: messageTokenThreshold (${result.data.observation.messageTokenThreshold}) ` +
+      `is below minimum safe threshold (${MIN_SAFE_MESSAGE_THRESHOLD}) — clamping to ${DEFAULT_MESSAGE_THRESHOLD}`,
+    )
+    ;(result.data.observation as { messageTokenThreshold: number }).messageTokenThreshold = DEFAULT_MESSAGE_THRESHOLD
+  }
+
   // Cast required: z.infer does not add readonly modifiers; OmgConfig wraps the
   // inferred type in DeepReadonly<...>. The satisfies check ensures the inferred
   // schema type and OmgConfig remain aligned at compile time.

--- a/src/cron/definitions.ts
+++ b/src/cron/definitions.ts
@@ -282,7 +282,9 @@ async function bootstrapCronHandler(ctx: CronContext): Promise<void> {
   try {
     const state = await readBootstrapState(omgRoot)
     if (state?.status === 'completed' && state.maintenanceDone) return
-  } catch { /* state unreadable — proceed to let tick handle it */ }
+  } catch (err) {
+    console.warn('[omg] cron: bootstrap state unreadable — proceeding to tick:', err)
+  }
 
   try {
     const result = await runBootstrapTick({

--- a/src/cron/definitions.ts
+++ b/src/cron/definitions.ts
@@ -278,6 +278,12 @@ async function bootstrapCronHandler(ctx: CronContext): Promise<void> {
     return
   }
 
+  // Skip tick entirely if bootstrap is fully completed — avoids lock churn every 5 min
+  try {
+    const state = await readBootstrapState(omgRoot)
+    if (state?.status === 'completed' && state.maintenanceDone) return
+  } catch { /* state unreadable — proceed to let tick handle it */ }
+
   try {
     const result = await runBootstrapTick({
       workspaceDir: ctx.workspaceDir,

--- a/src/dedup/semantic-prompts.ts
+++ b/src/dedup/semantic-prompts.ts
@@ -68,6 +68,37 @@ export function buildSemanticDedupUserPrompt(
   nodeContents: ReadonlyMap<string, string>,
   maxBodyChars: number,
 ): string {
+  return formatBlock(block, nodeContents, maxBodyChars)
+}
+
+/**
+ * Builds a batched user prompt containing multiple semantic dedup blocks.
+ * All blocks are concatenated with clear delimiters so the LLM can process
+ * them in a single call and return suggestions referencing any block.
+ */
+export function buildBatchedSemanticDedupUserPrompt(
+  blocks: readonly SemanticBlock[],
+  nodeContents: ReadonlyMap<string, string>,
+  maxBodyChars: number,
+): string {
+  const parts: string[] = []
+  parts.push(`Analyze the following ${blocks.length} block(s) for semantic duplicates.`)
+  parts.push('Each block groups related nodes — duplicates may exist within a block.\n')
+
+  for (let i = 0; i < blocks.length; i++) {
+    parts.push(`---\n`)
+    parts.push(`# Block ${i + 1} of ${blocks.length}\n`)
+    parts.push(formatBlock(blocks[i]!, nodeContents, maxBodyChars))
+  }
+
+  return parts.join('\n')
+}
+
+function formatBlock(
+  block: SemanticBlock,
+  nodeContents: ReadonlyMap<string, string>,
+  maxBodyChars: number,
+): string {
   const parts: string[] = []
 
   parts.push(`## Semantic Dedup Block — Domain: ${block.domain}`)

--- a/src/hooks/circuit-breaker.ts
+++ b/src/hooks/circuit-breaker.ts
@@ -1,0 +1,79 @@
+/**
+ * In-memory circuit breaker for LLM gateway calls.
+ *
+ * Prevents infinite retry loops when the gateway returns consecutive errors
+ * (500s, timeouts). After {@link FAILURE_THRESHOLD} consecutive failures,
+ * the circuit opens and all calls are skipped for {@link COOLDOWN_MS}.
+ * After cooldown, one probe call is allowed (half-open). If it succeeds
+ * the circuit closes; if it fails, cooldown resets.
+ *
+ * Scope: per-gateway instance (not per-session), since gateway errors
+ * affect all sessions equally.
+ */
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Consecutive failures before the circuit opens. */
+const FAILURE_THRESHOLD = 3
+
+/** Cooldown period in milliseconds (5 minutes). */
+const COOLDOWN_MS = 5 * 60 * 1000
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+interface BreakerState {
+  consecutiveFailures: number
+  lastFailureMs: number
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface CircuitBreaker {
+  /** Returns true if the circuit is open and calls should be skipped. */
+  shouldSkip(): boolean
+  /** Record a successful call — resets the breaker. */
+  recordSuccess(): void
+  /** Record a failed call — increments toward opening the circuit. */
+  recordFailure(): void
+}
+
+/**
+ * Creates a new circuit breaker instance.
+ * Pure factory — no global singletons. The caller owns the lifecycle.
+ */
+export function createCircuitBreaker(): CircuitBreaker {
+  const state: BreakerState = {
+    consecutiveFailures: 0,
+    lastFailureMs: 0,
+  }
+
+  return {
+    shouldSkip(): boolean {
+      if (state.consecutiveFailures < FAILURE_THRESHOLD) return false
+      const elapsed = Date.now() - state.lastFailureMs
+      if (elapsed >= COOLDOWN_MS) {
+        // Half-open: allow one probe call. Reset failure count so that if the
+        // probe fails, the threshold is crossed again immediately (3 → 1 + 1 fail = reopen).
+        state.consecutiveFailures = FAILURE_THRESHOLD - 1
+        return false
+      }
+      return true
+    },
+
+    recordSuccess(): void {
+      state.consecutiveFailures = 0
+      state.lastFailureMs = 0
+    },
+
+    recordFailure(): void {
+      state.consecutiveFailures++
+      state.lastFailureMs = Date.now()
+    },
+  }
+}

--- a/tests/unit/circuit-breaker.test.ts
+++ b/tests/unit/circuit-breaker.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createCircuitBreaker } from '../../src/hooks/circuit-breaker.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Advance Date.now() by `ms` milliseconds. */
+function advanceTime(ms: number): void {
+  vi.advanceTimersByTime(ms)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('createCircuitBreaker', () => {
+  it('returns a fresh circuit breaker in closed state', () => {
+    const cb = createCircuitBreaker()
+    expect(cb.shouldSkip()).toBe(false)
+  })
+
+  it('stays closed after fewer than 3 consecutive failures', () => {
+    const cb = createCircuitBreaker()
+    cb.recordFailure()
+    cb.recordFailure()
+    expect(cb.shouldSkip()).toBe(false)
+  })
+
+  it('opens after 3 consecutive failures', () => {
+    const cb = createCircuitBreaker()
+    cb.recordFailure()
+    cb.recordFailure()
+    cb.recordFailure()
+    expect(cb.shouldSkip()).toBe(true)
+  })
+
+  it('resets to closed on recordSuccess', () => {
+    const cb = createCircuitBreaker()
+    cb.recordFailure()
+    cb.recordFailure()
+    cb.recordSuccess()
+    // Counter reset — need 3 fresh failures to re-open
+    cb.recordFailure()
+    expect(cb.shouldSkip()).toBe(false)
+  })
+
+  it('stays open within the 5-minute cooldown window', () => {
+    const cb = createCircuitBreaker()
+    cb.recordFailure()
+    cb.recordFailure()
+    cb.recordFailure()
+
+    advanceTime(4 * 60 * 1000) // 4 minutes
+    expect(cb.shouldSkip()).toBe(true)
+  })
+
+  it('transitions to half-open after 5-minute cooldown', () => {
+    const cb = createCircuitBreaker()
+    cb.recordFailure()
+    cb.recordFailure()
+    cb.recordFailure()
+
+    advanceTime(5 * 60 * 1000) // exactly 5 minutes
+    // Half-open: allows one probe call
+    expect(cb.shouldSkip()).toBe(false)
+  })
+
+  it('closes fully when probe call succeeds in half-open state', () => {
+    const cb = createCircuitBreaker()
+    cb.recordFailure()
+    cb.recordFailure()
+    cb.recordFailure()
+
+    advanceTime(5 * 60 * 1000)
+    cb.shouldSkip() // transition to half-open
+    cb.recordSuccess()
+
+    // Fully closed — should not skip
+    expect(cb.shouldSkip()).toBe(false)
+  })
+
+  it('re-opens when probe call fails in half-open state', () => {
+    const cb = createCircuitBreaker()
+    cb.recordFailure()
+    cb.recordFailure()
+    cb.recordFailure()
+
+    advanceTime(5 * 60 * 1000)
+    cb.shouldSkip() // transition to half-open (consecutiveFailures = 2)
+    cb.recordFailure() // 2 + 1 = 3 → re-opens
+
+    expect(cb.shouldSkip()).toBe(true)
+  })
+
+  it('allows another probe after second cooldown expires', () => {
+    const cb = createCircuitBreaker()
+    // First open
+    cb.recordFailure()
+    cb.recordFailure()
+    cb.recordFailure()
+
+    // First half-open → probe fails → re-open
+    advanceTime(5 * 60 * 1000)
+    cb.shouldSkip()
+    cb.recordFailure()
+    expect(cb.shouldSkip()).toBe(true)
+
+    // Second cooldown → half-open again
+    advanceTime(5 * 60 * 1000)
+    expect(cb.shouldSkip()).toBe(false)
+  })
+
+  it('each createCircuitBreaker call returns an independent instance', () => {
+    const a = createCircuitBreaker()
+    const b = createCircuitBreaker()
+
+    a.recordFailure()
+    a.recordFailure()
+    a.recordFailure()
+
+    expect(a.shouldSkip()).toBe(true)
+    expect(b.shouldSkip()).toBe(false)
+  })
+})

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -313,10 +313,19 @@ describe('parseConfig — numeric thresholds', () => {
     )
   })
 
-  it('messageTokenThreshold minimum boundary 1 → accepted', () => {
+  it('messageTokenThreshold below 1000 → clamped to 8000', () => {
     expect(
       parseConfig({ observation: { messageTokenThreshold: 1 } }).observation.messageTokenThreshold
-    ).toBe(1)
+    ).toBe(8000)
+    expect(
+      parseConfig({ observation: { messageTokenThreshold: 999 } }).observation.messageTokenThreshold
+    ).toBe(8000)
+  })
+
+  it('messageTokenThreshold at 1000 → accepted as-is', () => {
+    expect(
+      parseConfig({ observation: { messageTokenThreshold: 1000 } }).observation.messageTokenThreshold
+    ).toBe(1000)
   })
 
   it('float messageTokenThreshold → throws ConfigValidationError', () => {


### PR DESCRIPTION
## Summary

- **Root cause found**: Gateway used JSON Schema `"minimum": 1` as default for `messageTokenThreshold`, causing observation to fire on every agent turn (~2050 LLM calls/day, 962 historical registrations with threshold=1)
- **Manifest minimum raised** from 1 → 4000 for both `messageTokenThreshold` and `observationTokenThreshold`
- **Runtime floor** in `parseConfig`: values below 1000 clamped to 8000 with warning log
- **Bootstrap noise suppressed**: service loop and cron handler skip tick entirely when state is `completed` + `maintenanceDone`
- **Semantic dedup batched**: was 1 LLM call per block (up to 15/run), now single batched call for all blocks
- **Circuit breaker**: 3 consecutive gateway failures → 5 min cooldown, prevents wasted LLM calls during 500 storms (93+ parser failures observed in one burst)
- **Reflection removed from agent-end**: runs exclusively from daily cron — eliminates unfiltered, age-unaware reflection passes on every observation cycle

## Test plan

- [x] TypeScript compiles (only pre-existing errors remain)
- [x] All 1432 unit tests pass
- [ ] Verify gateway registers with correct threshold after deploy
- [ ] Monitor `[omg] agent_end` logs to confirm observation skips when below threshold
- [ ] Verify circuit breaker logs during next gateway instability window
- [ ] Confirm semantic dedup shows "batched into 1 LLM call" in cron logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)